### PR TITLE
Updated search path to 2.4

### DIFF
--- a/src/main/java/org/apache/jmeter/JMeterMojo.java
+++ b/src/main/java/org/apache/jmeter/JMeterMojo.java
@@ -161,7 +161,7 @@ public class JMeterMojo extends AbstractMojo {
                             "upgrade.properties");
 
 
-            System.setProperty("search_paths", repoDir.toString() + "/org/apache/jmeter/jmeter/2.3/jmeter-2.3.jar");
+            System.setProperty("search_paths", repoDir.toString() + "/org/apache/jmeter/jmeter/2.4/jmeter-2.4.jar");
         } catch (IOException e) {
             throw new MojoExecutionException("Could not create temporary saveservice.properties", e);
         }


### PR DESCRIPTION
Hi Ronnie,

I've been having a bit of trouble with the plugin, specifically around using functions in my test plans.

After no small amount of digging i reckon i've got it down to this search path being incorrect and the jmeter-2.4.jar in the support jars zip being incomplete.

Theres still a problem when jmeter tries to reach out to its junit folder from the installation, but it still works just looks untidy.

I'll send you a message with the jar attached.

Cheers,

Tom
