### PR TITLE
JMX Token Parser and JMeter Artifact Resolution

### DIFF
--- a/src/main/java/org/apache/jmeter/JMeterMojo.java
+++ b/src/main/java/org/apache/jmeter/JMeterMojo.java
@@ -187,6 +187,12 @@ public class JMeterMojo extends AbstractMojo {
      */
     private String reportPostfix;
     
+    /**
+     * Add date to the report file 
+     * @parameter default-value=true
+     */
+    private Boolean reportDated;
+    
     private File workDir;
     private File jmeterLog;
     private DateFormat fmt = new SimpleDateFormat("yyMMdd");
@@ -354,7 +360,9 @@ public class JMeterMojo extends AbstractMojo {
             getLog().info("Executing test: " + test.getCanonicalPath());
 
             if (resultFileName == null) {
-                resultFileName = reportDir.toString() + File.separator + test.getName().substring(0, test.getName().lastIndexOf(".")) + "-" + fmt.format(new Date()) + ".xml";
+            	resultFileName = reportDir.toString() + File.separator + test.getName().substring(0, test.getName().lastIndexOf("."));            	
+            	if ( reportDated ) resultFileName += "-" + fmt.format(new Date());
+            	resultFileName += ".xml";
             }
             //delete file if it already exists
             new File(resultFileName).delete();
@@ -467,8 +475,11 @@ public class JMeterMojo extends AbstractMojo {
 
     /**
      * Replace the -J parameters that JMeter can use directly in the jmx file.
+     * 
      * @param replacements - list of replacements to make
+     * 
      * @param test - The full path and filename of the test to alter
+     * 
      * @throws MojoExecutionException exception
      */
     private void expandParameters(ArrayList<String> replacements,File test) throws MojoExecutionException {
@@ -477,7 +488,8 @@ public class JMeterMojo extends AbstractMojo {
     	
     	for (String s : replacements) {
     		if( s.toLowerCase().startsWith("-j") == false ) {
-    			m.put(s.substring(0,s.indexOf("=")),s.substring(s.indexOf("=")+1));
+    			if ( ! s.substring(s.indexOf("=")+1).equals("null") ) 
+    				m.put(s.substring(0,s.indexOf("=")),s.substring(s.indexOf("=")+1));
     		}
     	}
     	


### PR DESCRIPTION
Hey,

I found some problems with JMeter not actually using the passed in user properties via the "-J" command line option. At first I thought it was because it was being passed as one long string rather than separate arguments, i.e., "-Jfoo=bar -Jbar=foo" instead of "-Jfoo=bar", "-Jbar=foo" but it turns out that wasn't the issue. 

Instead of digging any further I knocked up a quick token parser to handle JMeter user property values (with defaults if necessary) and replace the values directly in the jmx before execution, then revert them back afterwards.

The second issue is to do with the JMeter artifacts. If we had a <dependecy> listed in the pom we were trying to resolve the location of that dependency and add it to the "search_paths" system property. I found that even with this correctly set JMeter's dynamic class loader was being overridden by Maven's classworlds loader. My first attempt at a fix was to add the dependencies to the plugin's classloader and let JMeter inherit them but then you start getting problems between the two different classloaders used in Maven 2 and Maven 3.

I found an easier solution was to simply put the <dependency> inside the <plugin> tag at which point Maven will automatically resolve and add them to the classworlds Class Realm for the plugin and JMeter would then inherit them. 

Last minor change was to introduce an option to remove the date tag on the produced xml report. This is because I needed a fixed name on the report to publish in Jenkins. It's a simple toggle in the pom using the <reportDated>true|false</reportDated> tag
