### PR TITLE
Add @Mojo(name="jmeter",requiresDirectInvocation=true) per comment from ...

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -148,6 +148,11 @@
             <version>2.2.1</version>
         </dependency>
         <dependency>
+            <groupId>org.apache.maven.plugin-tools</groupId>
+            <artifactId>maven-plugin-annotations</artifactId>
+            <version>3.1</version>
+        </dependency>
+        <dependency>
             <groupId>org.apache.maven.shared</groupId>
             <artifactId>maven-plugin-testing-harness</artifactId>
             <version>1.1</version>

--- a/src/main/java/com/lazerycode/jmeter/JMeterMojo.java
+++ b/src/main/java/com/lazerycode/jmeter/JMeterMojo.java
@@ -3,6 +3,7 @@ package com.lazerycode.jmeter;
 import com.lazerycode.jmeter.testrunner.TestManager;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.MojoFailureException;
+import org.apache.maven.plugins.annotations.Mojo;
 
 import java.io.File;
 import java.io.IOException;
@@ -16,6 +17,7 @@ import java.util.List;
  * @requiresProject true
  */
 @SuppressWarnings("JavaDoc")
+@Mojo(name="jmeter",requiresDirectInvocation=true)
 public class JMeterMojo extends JMeterAbstractMojo {
 
 	/**


### PR DESCRIPTION
...http://stackoverflow.com/questions/17799639/how-to-have-maven-run-just-jmeter-tests-no-other-life-cycles/ to enable direct invocation.
