### PR TITLE
#64: Added missed dependency causing file not found / error in NonGUIDriver error

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -236,6 +236,11 @@
         </dependency>
         <dependency>
             <groupId>org.apache.jmeter</groupId>
+            <artifactId>ApacheJMeter_native</artifactId>
+            <version>${jmeter.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.jmeter</groupId>
             <artifactId>ApacheJMeter_config</artifactId>
             <version>${jmeter.version}</version>
         </dependency>


### PR DESCRIPTION
I believe the cause of #64 is missed `ApacheJMeter-native.jar` file. This patch adds it as a dependency. I faced same file not found errors when playing with OS Process sampler. JMeter test plans get executed correctly with default JMeter installation but fail to do so with this maven plugin. I have compared contents of `lib/ext` directory and found this jar missing. After adding it, the problem was gone.

Maybe this issue is only valid for Mac OS X that I use, haven't tested it with other operating systems.
