### PR TITLE
Changes to allow system / global jmeter properties to be sent to remote clients.

### DIFF
--- a/src/main/java/com/lazerycode/jmeter/JMeterMojo.java
+++ b/src/main/java/com/lazerycode/jmeter/JMeterMojo.java
@@ -41,6 +41,7 @@ public class JMeterMojo extends JMeterAbstractMojo {
 		propertyConfiguration();
 		populateJMeterDirectoryTree();
 		initialiseJMeterArgumentsArray(true);
+		remoteConfig.setMasterPropertiesMap(pluginProperties.getMasterPropertiesMap()); 
 		TestManager jMeterTestManager = new TestManager(testArgs, testFilesDirectory, testFilesIncluded, testFilesExcluded, remoteConfig, suppressJMeterOutput, binDir);
 		getLog().info(" ");
 		if(proxyConfig != null) {

--- a/src/main/java/com/lazerycode/jmeter/configuration/JMeterArgumentsArray.java
+++ b/src/main/java/com/lazerycode/jmeter/configuration/JMeterArgumentsArray.java
@@ -1,18 +1,40 @@
 package com.lazerycode.jmeter.configuration;
 
+import static com.lazerycode.jmeter.UtilityFunctions.isNotSet;
+import static com.lazerycode.jmeter.UtilityFunctions.isSet;
+import static com.lazerycode.jmeter.configuration.JMeterCommandLineArguments.JMETER_HOME_OPT;
+import static com.lazerycode.jmeter.configuration.JMeterCommandLineArguments.JMLOGFILE_OPT;
+import static com.lazerycode.jmeter.configuration.JMeterCommandLineArguments.LOGFILE_OPT;
+import static com.lazerycode.jmeter.configuration.JMeterCommandLineArguments.LOGLEVEL;
+import static com.lazerycode.jmeter.configuration.JMeterCommandLineArguments.NONGUI_OPT;
+import static com.lazerycode.jmeter.configuration.JMeterCommandLineArguments.NONPROXY_HOSTS;
+import static com.lazerycode.jmeter.configuration.JMeterCommandLineArguments.PROPFILE2_OPT;
+import static com.lazerycode.jmeter.configuration.JMeterCommandLineArguments.PROXY_HOST;
+import static com.lazerycode.jmeter.configuration.JMeterCommandLineArguments.PROXY_PASSWORD;
+import static com.lazerycode.jmeter.configuration.JMeterCommandLineArguments.PROXY_PORT;
+import static com.lazerycode.jmeter.configuration.JMeterCommandLineArguments.PROXY_USERNAME;
+import static com.lazerycode.jmeter.configuration.JMeterCommandLineArguments.REMOTE_OPT;
+import static com.lazerycode.jmeter.configuration.JMeterCommandLineArguments.REMOTE_OPT_PARAM;
+import static com.lazerycode.jmeter.configuration.JMeterCommandLineArguments.REMOTE_STOP;
+import static com.lazerycode.jmeter.configuration.JMeterCommandLineArguments.TESTFILE_OPT;
+
+import java.io.File;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.Properties;
+import java.util.TreeSet;
+
 import org.apache.maven.plugin.MojoExecutionException;
 import org.joda.time.LocalDateTime;
 import org.joda.time.format.DateTimeFormatter;
 import org.joda.time.format.ISODateTimeFormat;
 
-import java.io.File;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.TreeSet;
-
-import static com.lazerycode.jmeter.UtilityFunctions.isNotSet;
-import static com.lazerycode.jmeter.UtilityFunctions.isSet;
-import static com.lazerycode.jmeter.configuration.JMeterCommandLineArguments.*;
+import com.lazerycode.jmeter.properties.JMeterPropertiesFiles;
+import com.lazerycode.jmeter.properties.PropertyContainer;
+import com.lazerycode.jmeter.properties.PropertyHandler;
 
 /**
  * Creates an arguments array to pass to the JMeter object to run tests.
@@ -23,6 +45,7 @@ public class JMeterArgumentsArray {
 
 	private final String jMeterHome;
 	private final boolean disableTests;
+
 	private final TreeSet<JMeterCommandLineArguments> argumentList = new TreeSet<JMeterCommandLineArguments>();
 	private DateTimeFormatter dateFormat = ISODateTimeFormat.basicDate();
 	private ProxyConfiguration proxyConfiguration;
@@ -36,7 +59,10 @@ public class JMeterArgumentsArray {
 	private String jmeterLogFileName;
 	private String logsDirectory;
 	private String resultsDirectory;
+	private PropertyHandler propertyHandler ;
 	private LogLevel overrideRootLogLevel;
+
+
 
 	/**
 	 * Create an instance of JMeterArgumentsArray
@@ -56,6 +82,18 @@ public class JMeterArgumentsArray {
 			disableTests = true;
 		}
 	}
+
+	
+	
+	public PropertyHandler getPropertyHandler() {
+		return propertyHandler;
+	}
+
+	public void setPropertyHandler(PropertyHandler propertyHandler) {
+		this.propertyHandler = propertyHandler;
+	}
+
+
 
 	public void setRemoteStop() {
 		argumentList.add(REMOTE_STOP);
@@ -159,6 +197,8 @@ public class JMeterArgumentsArray {
 		argumentList.add(LOGFILE_OPT);
 	}
 
+	
+
 	/**
 	 * Generate an arguments array representing the command line options you want to send to JMeter.
 	 * The order of the array is determined by the order the values in JMeterCommandLineArguments are defined.
@@ -169,6 +209,7 @@ public class JMeterArgumentsArray {
 	public List<String> buildArgumentsArray() throws MojoExecutionException {
 		if (!argumentList.contains(TESTFILE_OPT) && !disableTests) throw new MojoExecutionException("No test(s) specified!");
 		List<String> argumentsArray = new ArrayList<String>();
+		
 		for (JMeterCommandLineArguments argument : argumentList) {
 			switch (argument) {
 				case NONGUI_OPT:

--- a/src/main/java/com/lazerycode/jmeter/configuration/RemoteArgumentsArrayBuilder.java
+++ b/src/main/java/com/lazerycode/jmeter/configuration/RemoteArgumentsArrayBuilder.java
@@ -1,0 +1,52 @@
+package com.lazerycode.jmeter.configuration;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Properties;
+import java.util.Map.Entry;
+
+import com.lazerycode.jmeter.properties.JMeterPropertiesFiles;
+import com.lazerycode.jmeter.properties.PropertyContainer;
+
+public class RemoteArgumentsArrayBuilder {
+
+	public List<String> buildRemoteArgumentsArray(Map<JMeterPropertiesFiles, PropertyContainer> masterPropertiesMap){
+		if(masterPropertiesMap == null){
+			return Collections.emptyList(); 
+		}
+		
+		List<String> result = new ArrayList<String> () ;
+		for(Entry<JMeterPropertiesFiles, PropertyContainer> entry : masterPropertiesMap.entrySet()){
+			Properties properties = entry.getValue().getFinalPropertyObject(); 
+			switch(entry.getKey()){
+				case SYSTEM_PROPERTIES : {
+					result.addAll(buildTypedPropertiesForContainer(JMeterCommandLineArguments.SYSTEM_PROPERTY, properties)); 
+					break; 
+				}
+				case GLOBAL_PROPERTIES :  {
+					result.addAll(buildTypedPropertiesForContainer(JMeterCommandLineArguments.JMETER_GLOBAL_PROP, properties)); 
+					break; 
+				}
+				default : break; 
+			}
+		}
+		return result ; 
+	}
+	
+	private List<String> buildTypedPropertiesForContainer(JMeterCommandLineArguments cmdLineArg, Properties props){ 
+		List<String> result = new ArrayList<String> () ;
+		for(Entry<Object,Object> e : props.entrySet()){
+			if(cmdLineArg == JMeterCommandLineArguments.SYSTEM_PROPERTY){
+				result.add(cmdLineArg.getCommandLineArgument()+e.getKey()); 
+				result.add(e.getValue().toString());
+			}else{
+				result.add(cmdLineArg.getCommandLineArgument()+e.getKey()+"="+e.getValue()); 
+			}
+		}
+		return result; 
+	}
+	
+	
+}

--- a/src/main/java/com/lazerycode/jmeter/configuration/RemoteConfiguration.java
+++ b/src/main/java/com/lazerycode/jmeter/configuration/RemoteConfiguration.java
@@ -1,5 +1,10 @@
 package com.lazerycode.jmeter.configuration;
 
+import java.util.Map;
+
+import com.lazerycode.jmeter.properties.JMeterPropertiesFiles;
+import com.lazerycode.jmeter.properties.PropertyContainer;
+
 /**
  * This is used by the TestManager to configure remote serverList and stopServersAfterTests settings for each test run.
  * <p/>
@@ -24,8 +29,11 @@ public class RemoteConfiguration {
     private boolean stopServersAfterTests = false;
     private boolean startAndStopServersForEachTest = false;
 	private String serverList = null;
+	private Map<JMeterPropertiesFiles, PropertyContainer> masterPropertiesMap = null;
 
-    /**
+
+
+	/**
      * @return Stop remote servers when the test finishes
      */
     public boolean isStopServersAfterTests() {
@@ -49,7 +57,9 @@ public class RemoteConfiguration {
         return startServersBeforeTests;
     }
 
-    /**
+
+
+	/**
      * Start all remote servers as defined in jmeter.properties when the test starts
      * Default: {@link false Boolean.FALSE}
      *
@@ -101,4 +111,18 @@ public class RemoteConfiguration {
     public String toString() {
         return "RemoteConfiguration [ " + "Start=" + getServerList() + ", Stop=" + isStopServersAfterTests() + ", StartAndStopOnce=" + isStartAndStopServersForEachTest() + ", StartAll=" + isStartServersBeforeTests() + " ]";
     }
+    
+    
+    /**
+     *  
+     * @return propertycontainers with information specified in the various property sources. 
+     */
+    public Map<JMeterPropertiesFiles, PropertyContainer> getMasterPropertiesMap() {
+		return masterPropertiesMap;
+	}
+
+	public void setMasterPropertiesMap(
+			Map<JMeterPropertiesFiles, PropertyContainer> masterPropertiesMap) {
+		this.masterPropertiesMap = masterPropertiesMap;
+	}
 }

--- a/src/main/java/com/lazerycode/jmeter/properties/PropertyHandler.java
+++ b/src/main/java/com/lazerycode/jmeter/properties/PropertyHandler.java
@@ -19,6 +19,7 @@ import java.util.jar.JarFile;
 public class PropertyHandler extends JMeterMojo {
 
 	private final EnumMap<JMeterPropertiesFiles, PropertyContainer> masterPropertiesMap = new EnumMap<JMeterPropertiesFiles, PropertyContainer>(JMeterPropertiesFiles.class);
+
 	private File propertySourceDirectory;
 	private File propertyOutputDirectory;
 	private boolean replaceDefaultProperties;
@@ -77,6 +78,15 @@ public class PropertyHandler extends JMeterMojo {
 			}
 		}
 	}
+	
+	/**
+	 *  
+	 * @param props
+	 * @return PropertyContainer for jvm property access / non file based. 
+	 */
+	public PropertyContainer getPropertyContainer(JMeterPropertiesFiles props) { 
+		return masterPropertiesMap.get(props); 
+	}
 
 	/**
 	 * Check that the source directory exists, throw an error if it does not
@@ -107,6 +117,17 @@ public class PropertyHandler extends JMeterMojo {
 		this.propertyOutputDirectory = value;
 	}
 
+	/**
+	 * 
+	 * @return full property map for the application.
+	 */
+	//doesnt make sense to use the files for remote access as jmeter wont pick it up 
+	public EnumMap<JMeterPropertiesFiles, PropertyContainer> getMasterPropertiesMap() {
+		return masterPropertiesMap;
+	}
+
+	
+	
 	public void setJMeterProperties(Map<String, String> value) {
 		if (UtilityFunctions.isNotSet(value)) return;
 		this.getPropertyObject(JMeterPropertiesFiles.JMETER_PROPERTIES).setCustomPropertyMap(value);
@@ -137,7 +158,7 @@ public class PropertyHandler extends JMeterMojo {
 		this.getPropertyObject(JMeterPropertiesFiles.GLOBAL_PROPERTIES).setCustomPropertyMap(value);
 	}
 
-	PropertyContainer getPropertyObject(JMeterPropertiesFiles value) {
+	public PropertyContainer getPropertyObject(JMeterPropertiesFiles value) {
 		return this.masterPropertiesMap.get(value);
 	}
 

--- a/src/test/java/com/lazerycode/jmeter/configuration/RemoteArgumentsArrayBuilderTest.java
+++ b/src/test/java/com/lazerycode/jmeter/configuration/RemoteArgumentsArrayBuilderTest.java
@@ -1,0 +1,63 @@
+package com.lazerycode.jmeter.configuration;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Properties;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import com.lazerycode.jmeter.properties.JMeterPropertiesFiles;
+import com.lazerycode.jmeter.properties.PropertyContainer;
+
+
+public class RemoteArgumentsArrayBuilderTest {
+
+	private Map<JMeterPropertiesFiles, PropertyContainer> inputMap = new HashMap<JMeterPropertiesFiles, PropertyContainer>(); 
+	private RemoteArgumentsArrayBuilder arrayBuilder = new RemoteArgumentsArrayBuilder() ; 
+	private PropertyContainer container = new PropertyContainer(); 
+	
+	@Before
+	public void setup() { 
+		Properties props = new Properties(); 
+		props.setProperty("hello","world"); 
+		container.setFinalPropertyObject(props); 
+	}
+	
+	@Test
+	public void shouldReturnEmptyListWhenNoPropsPassed() {
+		List<String> result = arrayBuilder.buildRemoteArgumentsArray(null); 
+		assertTrue(result.isEmpty()); 
+	}
+
+	@Test
+	public void shouldBuildCommandLineArgumentsForSystemProperties() {	
+
+		inputMap.put(JMeterPropertiesFiles.SYSTEM_PROPERTIES, container);	
+		List<String> result = arrayBuilder.buildRemoteArgumentsArray(inputMap); 
+		assertEquals(2,result.size());
+		assertEquals("-Dhello",result.get(0)); 
+		assertEquals("world",result.get(1));
+	}
+	
+	@Test
+	public void shouldBuildCommandLineArgumentsGlobalProperties() {
+
+		inputMap.put(JMeterPropertiesFiles.GLOBAL_PROPERTIES, container);	
+		List<String> result = arrayBuilder.buildRemoteArgumentsArray(inputMap); 
+		assertEquals(1,result.size());
+		assertEquals("-Ghello=world",result.get(0)); 
+	}
+	
+	@Test
+	public void shoulIgnoreOtherTypesOfProperties() {
+
+		inputMap.put(JMeterPropertiesFiles.JMETER_PROPERTIES, container);	
+		List<String> result = arrayBuilder.buildRemoteArgumentsArray(inputMap); 
+		assertTrue(result.isEmpty()); 
+	}
+}


### PR DESCRIPTION
The plugin should be able to support sending of system and global properties to remote clients which it currently doesn't. I'm not sure if you have a particular approach you'd like to use for this so I just did a quick fix using the master properties map that's built in the initial phases of the jmeter mojo. 

One of the primary problems that this solves is the inability to set java.rmi.server.hostname, which solves a heap of callback problems when the remote workers are trying to send info back to server. 

Should serve as a useful starting point at least. 
