### PR TITLE
Disabling build failed when source directory is not found

### DIFF
--- a/src/main/java/com/lazerycode/jmeter/JMeterAbstractMojo.java
+++ b/src/main/java/com/lazerycode/jmeter/JMeterAbstractMojo.java
@@ -207,6 +207,12 @@ public abstract class JMeterAbstractMojo extends AbstractMojo {
 	@Parameter(defaultValue = "false")
 	protected boolean skipTests;
 
+	/**
+	 * Build failed if source directory is not found.
+	 */
+	@Parameter(defaultValue = "true")
+	protected boolean sourceDirFailed;
+
 	//------------------------------------------------------------------------------------------------------------------
 
 	/**
@@ -258,7 +264,7 @@ public abstract class JMeterAbstractMojo extends AbstractMojo {
 	}
 
 	protected void propertyConfiguration() throws MojoExecutionException {
-		pluginProperties = new PropertyHandler(testFilesDirectory, binDir, getArtifactNamed(jmeterConfigArtifact), propertiesReplacedByCustomFiles);
+		pluginProperties = new PropertyHandler(testFilesDirectory, binDir, getArtifactNamed(jmeterConfigArtifact), propertiesReplacedByCustomFiles, sourceDirFailed);
 		pluginProperties.setJMeterProperties(propertiesJMeter);
 		pluginProperties.setJMeterGlobalProperties(propertiesGlobal);
 		pluginProperties.setJMeterSaveServiceProperties(propertiesSaveService);

--- a/src/main/java/com/lazerycode/jmeter/testrunner/TestManager.java
+++ b/src/main/java/com/lazerycode/jmeter/testrunner/TestManager.java
@@ -133,6 +133,7 @@ public class TestManager extends JMeterMojo {
 	private List<String> generateTestList() {
 		List<String> jmeterTestFiles = new ArrayList<String>();
 		DirectoryScanner scanner = new DirectoryScanner();
+		scanner.setErrorOnMissingDir(false);
 		scanner.setBasedir(this.testFilesDirectory);
 		scanner.setIncludes(this.testFilesIncluded == null ? new String[]{"**/*.jmx"} : this.testFilesIncluded.toArray(new String[jmeterTestFiles.size()]));
 		if (this.testFilesExcluded != null) {

--- a/src/test/java/com/lazerycode/jmeter/properties/PropertyHandlerTest.java
+++ b/src/test/java/com/lazerycode/jmeter/properties/PropertyHandlerTest.java
@@ -1,17 +1,30 @@
 package com.lazerycode.jmeter.properties;
 
-import org.junit.BeforeClass;
+import java.io.File;
+
+import org.apache.maven.plugin.MojoExecutionException;
+import org.junit.Assert;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
 
 public class PropertyHandlerTest {
 
-//    @BeforeClass
-//    public void setUp(){
-//
-//    }
+    @Rule
+    public TemporaryFolder folder = new TemporaryFolder();
 
     @Test
-    public void foo() throws Exception{
+    public void testPropertyHandlerWithSourceDirectory() throws Exception {
+       Assert.assertNotNull(new PropertyHandler(folder.newFolder("source"), folder.newFolder("target"), null, false, true));
+    }
 
+    @Test(expected=MojoExecutionException.class)
+    public void testPropertyHandlerWithoutSourceDirectoryWithError() throws Exception {
+        new PropertyHandler(new File("/dir_no_exists"), folder.newFolder("target"), null, false, true);
+    }
+
+    @Test
+    public void testPropertyHandlerWithoutSourceDirectoryWithoutError() throws Exception {
+        Assert.assertNotNull(new PropertyHandler(new File("/dir_no_exists"), folder.newFolder("target"), null, false, false));
     }
 }


### PR DESCRIPTION
If you add configuration

<configuration>
<sourceDirFailed>false</sourceDirFailed>
</configuration>

build no failed if source directory does not exist. Only log is print.

[INFO] -------------------------------------------------------
[INFO] P E R F O R M A N C E T E S T S
[INFO] -------------------------------------------------------
[INFO]

[INFO] Property source directory '/home/user/project/src/test/jmeter' does not exist!
[INFO]

[INFO]

[INFO] Test Results:
[INFO]

[INFO] Tests Run: 0, Failures: 0
[INFO]

Thanks to integrate this pull request.
