### PR TITLE
Allowing injection of Java to Jmeter

### DIFF
--- a/src/main/java/com/lazerycode/jmeter/configuration/JMeterProcessJVMSettings.java
+++ b/src/main/java/com/lazerycode/jmeter/configuration/JMeterProcessJVMSettings.java
@@ -12,8 +12,9 @@ import java.util.List;
  * {@code
  * 	<configuration>
  *      <jMeterProcessJVMSettings>
- *          <xms>true</xms>
- *          <xmx>true</xmx>
+ *          <javaRuntime>{env.JAVA_HOME}/bin/java</javaRuntime>
+ *          <xms>512</xms>
+ *          <xmx>1024</xmx>
  *          <arguments>
  *              <argument>foo</argument>
  *          </arguments>
@@ -28,6 +29,7 @@ public class JMeterProcessJVMSettings {
 
 	private int xms = 512;
 	private int xmx = 512;
+	private String java = "java";
 	private List<String> arguments = new ArrayList<String>();
 
 	public int getXms() {
@@ -52,5 +54,13 @@ public class JMeterProcessJVMSettings {
 
 	public void setArguments(List<String> arguments) {
 		this.arguments = arguments;
+	}
+
+	public void setJavaRuntime(String java) {
+		this.java = java;
+	}
+
+	public String getJavaRuntime() {
+		return this.java;
 	}
 }

--- a/src/main/java/com/lazerycode/jmeter/testrunner/JMeterProcessBuilder.java
+++ b/src/main/java/com/lazerycode/jmeter/testrunner/JMeterProcessBuilder.java
@@ -14,6 +14,7 @@ public class JMeterProcessBuilder {
 	private int initialHeapSizeInMegaBytes;
 	private int maximumHeapSizeInMegaBytes;
 	private String workingDirectory;
+	private String javaRuntime;
 	private List<String> userSuppliedArguments;
 	private List<String> mainClassArguments = new ArrayList<String>();
 
@@ -24,6 +25,7 @@ public class JMeterProcessBuilder {
 		this.initialHeapSizeInMegaBytes = settings.getXms();
 		this.maximumHeapSizeInMegaBytes = settings.getXmx();
 		this.userSuppliedArguments = settings.getArguments();
+		this.javaRuntime = settings.getJavaRuntime();
 	}
 
 	public void setWorkingDirectory(File workingDirectory) throws MojoExecutionException {
@@ -41,7 +43,6 @@ public class JMeterProcessBuilder {
 	}
 
 	private String[] constructArgumentsList() {
-		String javaRuntime = "java";
 		String mainClass = "ApacheJMeter.jar";
 
 		List<String> argumentsList = new ArrayList<String>();


### PR DESCRIPTION
In our CI systems there is no java in our PATH, instead we utilize environment variables to inject the version of Java that we need via the JAVA_HOME environment variable.

This commit provides the code necessary to be able to override the default hard coding of "java" and the expectation that it is always on your PATH.
