### PR TITLE
Adding the ability to open a JMX file into Jmeter GUI (only within the '...

### DIFF
--- a/src/main/java/com/lazerycode/jmeter/JMeterGUIMojo.java
+++ b/src/main/java/com/lazerycode/jmeter/JMeterGUIMojo.java
@@ -4,7 +4,9 @@ import com.lazerycode.jmeter.testrunner.JMeterProcessBuilder;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.MojoFailureException;
 import org.apache.maven.plugins.annotations.Mojo;
+import org.apache.maven.plugins.annotations.Parameter;
 
+import java.io.File;
 import java.io.IOException;
 
 /**
@@ -14,6 +16,12 @@ import java.io.IOException;
  */
 @Mojo(name = "gui")
 public class JMeterGUIMojo extends JMeterAbstractMojo {
+
+	/**
+	 * Convenient to open a test file into the GUI after it is loaded.
+	 */
+	@Parameter
+	private File guiTestFile;
 
 	/**
 	 * Load the JMeter GUI
@@ -48,5 +56,11 @@ public class JMeterGUIMojo extends JMeterAbstractMojo {
 		} catch (IOException e) {
 			getLog().error(e.getMessage());
 		}
+	}
+
+	@Override
+	protected void initialiseJMeterArgumentsArray(boolean disableGUI) throws MojoExecutionException {
+		super.initialiseJMeterArgumentsArray(disableGUI);
+		testArgs.setTestFile(guiTestFile);
 	}
 }

--- a/src/main/java/com/lazerycode/jmeter/configuration/JMeterArgumentsArray.java
+++ b/src/main/java/com/lazerycode/jmeter/configuration/JMeterArgumentsArray.java
@@ -23,7 +23,7 @@ import static com.lazerycode.jmeter.configuration.JMeterCommandLineArguments.*;
 public class JMeterArgumentsArray {
 
 	private final String jMeterHome;
-	private final boolean disableTests;
+	private boolean disableTests;
 
 	private final TreeSet<JMeterCommandLineArguments> argumentList = new TreeSet<JMeterCommandLineArguments>();
 	private DateTimeFormatter dateFormat = ISODateTimeFormat.basicDate();
@@ -153,7 +153,7 @@ public class JMeterArgumentsArray {
 	}
 
 	public void setTestFile(File value) {
-		if (isNotSet(value) || disableTests) return;
+		if (isNotSet(value)) return;
 		testFile = value.getAbsolutePath();
 		if (timestampResults) {
 			//TODO investigate when timestamp is generated.
@@ -171,6 +171,7 @@ public class JMeterArgumentsArray {
 		}
 		argumentList.add(TESTFILE_OPT);
 		argumentList.add(LOGFILE_OPT);
+		disableTests = false;
 	}
 
 

--- a/src/test/java/com/lazerycode/jmeter/configuration/JMeterArgumentsArrayTest.java
+++ b/src/test/java/com/lazerycode/jmeter/configuration/JMeterArgumentsArrayTest.java
@@ -67,10 +67,8 @@ public class JMeterArgumentsArrayTest {
 		JMeterArgumentsArray testArgs = new JMeterArgumentsArray(enableGUI, "target/jmeter/");
 		testArgs.setTestFile(new File(this.testFile.toURI()));
 
-		assertThat(testArgs.getResultsLogFileName(),
-				is(equalTo(null)));
 		assertThat(UtilityFunctions.humanReadableCommandLineOutput(testArgs.buildArgumentsArray()),
-				is(equalTo("-d target/jmeter/")));
+				is(equalTo("-t " + testFilePath + " -l " + testArgs.getResultsLogFileName() + " -d target/jmeter/")));
 	}
 
 	@Test


### PR DESCRIPTION
Hello and thank you for you work and sharing.
I work on a professional project and we developped a maven plugin which generates from scratch our JMX JMeter test file.

When the developper is updating the maven plugin code and therefore our JMX, we wanted to be able to launch JMeter and the newly generated JMX file for validity and pre-test purpose. So we decided to use your plugin but the 'gui' goal does not allow to specify a "-t" option to JMeter.

So we added the "guiTestFile" parameter only to the GUI MOJO.
Could you check our code and eventually integrate it on the next release.