### PR TITLE
Socks proxy support

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
 
     <groupId>com.lazerycode.jmeter</groupId>
     <artifactId>jmeter-maven-plugin</artifactId>
-    <version>1.10.2-SNAPSHOT</version>
+    <version>1.10.0</version>
     <packaging>maven-plugin</packaging>
     <name>JMeter Maven Plugin</name>
     <description>A plugin to allow you to run JMeter tests with Maven.</description>

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
 
     <groupId>com.lazerycode.jmeter</groupId>
     <artifactId>jmeter-maven-plugin</artifactId>
-    <version>1.10.0</version>
+    <version>1.10.2-SNAPSHOT</version>
     <packaging>maven-plugin</packaging>
     <name>JMeter Maven Plugin</name>
     <description>A plugin to allow you to run JMeter tests with Maven.</description>

--- a/src/main/java/com/lazerycode/jmeter/JMeterAbstractMojo.java
+++ b/src/main/java/com/lazerycode/jmeter/JMeterAbstractMojo.java
@@ -151,6 +151,12 @@ public abstract class JMeterAbstractMojo extends AbstractMojo {
 	protected ProxyConfiguration proxyConfig;
 
 	/**
+	 * Value class that wraps SOCKS proxy configurations.
+	 */
+	@Parameter
+	protected SocksProxyConfiguration socksProxyConfig;
+
+	/**
 	 * Value class that wraps all remote configurations.
 	 */
 	@Parameter
@@ -455,6 +461,7 @@ public abstract class JMeterAbstractMojo extends AbstractMojo {
 			}
 		}
 		testArgs.setProxyConfig(proxyConfig);
+		testArgs.setSocksProxyConfig(socksProxyConfig);
 		testArgs.setACustomPropertiesFile(customPropertiesFile);
 		testArgs.setLogRootOverride(overrideRootLogLevel);
 		testArgs.setLogsDirectory(logsDir.getAbsolutePath());

--- a/src/main/java/com/lazerycode/jmeter/configuration/JMeterArgumentsArray.java
+++ b/src/main/java/com/lazerycode/jmeter/configuration/JMeterArgumentsArray.java
@@ -28,6 +28,7 @@ public class JMeterArgumentsArray {
 	private final TreeSet<JMeterCommandLineArguments> argumentList = new TreeSet<JMeterCommandLineArguments>();
 	private DateTimeFormatter dateFormat = ISODateTimeFormat.basicDate();
 	private ProxyConfiguration proxyConfiguration;
+	private SocksProxyConfiguration socksProxyConfiguration;
 	private boolean timestampResults = false;
 	private boolean appendTimestamp = false;
 	private String resultFileExtension = ".jtl";
@@ -101,6 +102,16 @@ public class JMeterArgumentsArray {
 		}
 		if (isSet(proxyConfiguration.getHostExclusions())) {
 			argumentList.add(NONPROXY_HOSTS);
+		}
+	}
+
+	public void setSocksProxyConfig(SocksProxyConfiguration configuration) {
+		if (configuration == null) return;
+
+		this.socksProxyConfiguration = configuration;
+		if (isSet(socksProxyConfiguration.getHost())) {
+			argumentList.add(SOCKS_PROXY_HOST);
+			argumentList.add(SOCKS_PROXY_PORT);
 		}
 	}
 
@@ -232,6 +243,14 @@ public class JMeterArgumentsArray {
 				case NONPROXY_HOSTS:
 					argumentsArray.add(NONPROXY_HOSTS.getCommandLineArgument());
 					argumentsArray.add(proxyConfiguration.getHostExclusions());
+					break;
+				case SOCKS_PROXY_HOST:
+					argumentsArray.add(SOCKS_PROXY_HOST.getCommandLineArgument());
+					argumentsArray.add(socksProxyConfiguration.getHost());
+					break;
+				case SOCKS_PROXY_PORT:
+					argumentsArray.add(SOCKS_PROXY_PORT.getCommandLineArgument());
+					argumentsArray.add(socksProxyConfiguration.getPort());
 					break;
 				case REMOTE_STOP:
 					argumentsArray.add(REMOTE_STOP.getCommandLineArgument());

--- a/src/main/java/com/lazerycode/jmeter/configuration/JMeterCommandLineArguments.java
+++ b/src/main/java/com/lazerycode/jmeter/configuration/JMeterCommandLineArguments.java
@@ -8,29 +8,31 @@ package com.lazerycode.jmeter.configuration;
  */
 public enum JMeterCommandLineArguments {
 
-    NONGUI_OPT("n"),            //ALWAYS_SET - This plugin always runs JMeter in non-gui mode.
-    TESTFILE_OPT("t"),          //ALWAYS_SET - This is how we pass our test file list over to JMeter.
-    LOGFILE_OPT("l"),           //ALWAYS_SET - Test name is used for logfile name (<testname>.jtl).
-    JMETER_HOME_OPT("d"),       //ALWAYS_SET - The JMeter dir structure is created by the plugin.
-    SYSTEM_PROPFILE("S"),       //NOT_USED - We place the system.properties in the correct place on the filesystem.
-    SYSTEM_PROPERTY("D"),       //DOCUMENTED
-    JMETER_PROPERTY("J"),       //DOCUMENTED
-    JMETER_GLOBAL_PROP("G"),    //DOCUMENTED
-    LOGLEVEL("L"),              //DOCUMENTED
-    PROPFILE2_OPT("q"),         //DOCUMENTED
-    PROXY_HOST("H"),            //DOCUMENTED
-    PROXY_PORT("P"),            //DOCUMENTED
-    PROXY_USERNAME("u"),        //DOCUMENTED
-    PROXY_PASSWORD("a"),        //DOCUMENTED
-    NONPROXY_HOSTS("N"),        //DOCUMENTED
-    JMLOGFILE_OPT("j"),         //ALWAYS_SET - Test name is used for logfile name (<testname>.log).
-    REMOTE_OPT("r"),            //DOCUMENTED
-    REMOTE_OPT_PARAM("R"),      //DOCUMENTED
-    REMOTE_STOP("X"),           //DOCUMENTED
-    PROPFILE_OPT("p"),          //NOT_USED - We place the jmeter.properties in the correct place on the filesystem.
-    SERVER_OPT("s"),            //NOT_USED - We are never going to start up a server instance on the command line, we are only running tests.
-    VERSION_OPT("v"),           //NOT_USED - Prints version information and exits.
-    HELP_OPT("h");              //NOT_USED - Prints help information and exits.
+    NONGUI_OPT("n"),                        //ALWAYS_SET - This plugin always runs JMeter in non-gui mode.
+    TESTFILE_OPT("t"),                      //ALWAYS_SET - This is how we pass our test file list over to JMeter.
+    LOGFILE_OPT("l"),                       //ALWAYS_SET - Test name is used for logfile name (<testname>.jtl).
+    JMETER_HOME_OPT("d"),                   //ALWAYS_SET - The JMeter dir structure is created by the plugin.
+    SYSTEM_PROPFILE("S"),                   //NOT_USED - We place the system.properties in the correct place on the filesystem.
+    SYSTEM_PROPERTY("D"),                   //DOCUMENTED
+    JMETER_PROPERTY("J"),                   //DOCUMENTED
+    JMETER_GLOBAL_PROP("G"),                //DOCUMENTED
+    LOGLEVEL("L"),                          //DOCUMENTED
+    PROPFILE2_OPT("q"),                     //DOCUMENTED
+    PROXY_HOST("H"),                        //DOCUMENTED
+    PROXY_PORT("P"),                        //DOCUMENTED
+    PROXY_USERNAME("u"),                    //DOCUMENTED
+    PROXY_PASSWORD("a"),                    //DOCUMENTED
+    NONPROXY_HOSTS("N"),                    //DOCUMENTED
+    SOCKS_PROXY_HOST("DsocksProxyHost"),    //DOCUMENTED
+    SOCKS_PROXY_PORT("DsocksProxyPort"),    //DOCUMENTED
+    JMLOGFILE_OPT("j"),                     //ALWAYS_SET - Test name is used for logfile name (<testname>.log).
+    REMOTE_OPT("r"),                        //DOCUMENTED
+    REMOTE_OPT_PARAM("R"),                  //DOCUMENTED
+    REMOTE_STOP("X"),                       //DOCUMENTED
+    PROPFILE_OPT("p"),                      //NOT_USED - We place the jmeter.properties in the correct place on the filesystem.
+    SERVER_OPT("s"),                        //NOT_USED - We are never going to start up a server instance on the command line, we are only running tests.
+    VERSION_OPT("v"),                       //NOT_USED - Prints version information and exits.
+    HELP_OPT("h");                          //NOT_USED - Prints help information and exits.
 
     private final String commandLineArgument;
 

--- a/src/main/java/com/lazerycode/jmeter/configuration/SocksProxyConfiguration.java
+++ b/src/main/java/com/lazerycode/jmeter/configuration/SocksProxyConfiguration.java
@@ -1,0 +1,72 @@
+package com.lazerycode.jmeter.configuration;
+
+import static com.lazerycode.jmeter.UtilityFunctions.isNotSet;
+import static com.lazerycode.jmeter.UtilityFunctions.isSet;
+
+/**
+ * Is used for configuration of SOCKS proxy related configuration.
+ * <p/>
+ * Configuration in pom.xml:
+ * <p/>
+ * <pre>
+ * {@code
+ * <socksProxyConfig>
+ *     <host></host>
+ *     <port></port>
+ * </socksProxyConfig>
+ * }
+ * </pre>
+ *
+ */
+public class SocksProxyConfiguration {
+
+	private String host = null;
+	private Integer port = null;
+
+	/**
+	 * @return SOCKS proxy host name
+	 */
+	public String getHost() {
+		return host;
+	}
+
+	/**
+	 * SOCKS proxy host name
+	 *
+	 * @param host String
+	 */
+	public void setHost(String host) {
+		this.host = host;
+	}
+
+	/**
+	 * @return SOCKS proxy port as long as a host is set
+	 */
+	public String getPort() {
+		if (isNotSet(host)) return null;
+		return port.toString();
+	}
+
+	/**
+	 * SOCKS proxy port
+	 *
+	 * @param port Integer
+	 */
+	public void setPort(Integer port) {
+		this.port = port;
+	}
+
+	/**
+	 * Proxy details formatted for command line output.
+	 *
+	 * @return String
+	 */
+	@Override
+	public String toString() {
+		String proxyDetails = "SOCKS proxy server is not being used.";
+		if (isSet(host)) {
+			proxyDetails = "SOCKS proxy Details:\n\nHost: " + host + ":" + port + "\n";
+		}
+		return proxyDetails + "\n";
+	}
+}

--- a/src/main/java/com/lazerycode/jmeter/configuration/SocksProxyConfiguration.java
+++ b/src/main/java/com/lazerycode/jmeter/configuration/SocksProxyConfiguration.java
@@ -65,7 +65,7 @@ public class SocksProxyConfiguration {
 	public String toString() {
 		String proxyDetails = "SOCKS proxy server is not being used.";
 		if (isSet(host)) {
-			proxyDetails = "SOCKS proxy Details:\n\nHost: " + host + ":" + port + "\n";
+			proxyDetails = "SOCKS Proxy Details:\n\nHost: " + host + ":" + port + "\n";
 		}
 		return proxyDetails + "\n";
 	}

--- a/src/test/java/com/lazerycode/jmeter/configuration/JMeterArgumentsArrayTest.java
+++ b/src/test/java/com/lazerycode/jmeter/configuration/JMeterArgumentsArrayTest.java
@@ -251,6 +251,30 @@ public class JMeterArgumentsArrayTest {
 	}
 
 	@Test
+	public void validateJMeterSetSocksProxyHost() throws Exception {
+		SocksProxyConfiguration socksProxyConfiguration = new SocksProxyConfiguration();
+		socksProxyConfiguration.setHost("http://10.10.50.43");
+		socksProxyConfiguration.setPort(8080);
+		JMeterArgumentsArray testArgs = new JMeterArgumentsArray(disableGUI, "target/jmeter/");
+		testArgs.setTestFile(new File(this.testFile.toURI()));
+
+		testArgs.setSocksProxyConfig(socksProxyConfiguration);
+
+		assertThat(UtilityFunctions.humanReadableCommandLineOutput(testArgs.buildArgumentsArray()),
+				is(equalTo("-n -t " + testFilePath + " -l " + testArgs.getResultsLogFileName() + " -d target/jmeter/ -DsocksProxyHost http://10.10.50.43 -DsocksProxyPort 8080")));
+		assertThat(socksProxyConfiguration.toString(),
+				is(equalTo("SOCKS Proxy Details:\n\nHost: http://10.10.50.43:8080\n\n")));
+	}
+
+	@Test
+	public void checkSocksProxyDetailsReturnedWhenHostAndPortNotSet() {
+		SocksProxyConfiguration socksProxyConfiguration = new SocksProxyConfiguration();
+
+		assertThat(socksProxyConfiguration.toString(),
+				is(equalTo("SOCKS proxy server is not being used.\n")));
+	}
+
+	@Test
 	public void validateSetRemoteStop() throws Exception {
 		JMeterArgumentsArray testArgs = new JMeterArgumentsArray(disableGUI, "target/jmeter/");
 		testArgs.setTestFile(new File(this.testFile.toURI()));


### PR DESCRIPTION
I need to use JMeter with SOCKS proxy as described there:
https://www.learnosity.com/blog/2010/01/jmeter-over-ssh-socks-proxy/

More about SOCKS proxy here, in section 2.4:
http://docs.oracle.com/javase/8/docs/technotes/guides/net/proxies.html

Currently this plugin doesn't support SOCKS proxy. This PR will change that. Tested, just works!

When this is merged, I'll update wiki as well.