### PR TITLE
Add pre and post script launcher

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
 
     <groupId>com.lazerycode.jmeter</groupId>
     <artifactId>jmeter-maven-plugin</artifactId>
-    <version>1.10.2-SNAPSHOT</version>
+    <version>1.10.2.SEB-SNAPSHOT</version>
     <packaging>maven-plugin</packaging>
     <name>JMeter Maven Plugin</name>
     <description>A plugin to allow you to run JMeter tests with Maven.</description>

--- a/src/main/java/com/lazerycode/jmeter/JMeterAbstractMojo.java
+++ b/src/main/java/com/lazerycode/jmeter/JMeterAbstractMojo.java
@@ -228,6 +228,42 @@ public abstract class JMeterAbstractMojo extends AbstractMojo {
 	@Parameter(defaultValue = "${project.build.directory}/jmeter")
 	protected transient File workDir;
 
+	//------------------------------------------------------------------------------------------------------------------
+
+	/****************************************************************************
+	 * Pre and Post Processing
+	 ****************************************************************************/
+	/**
+	 * Global Pre Processing Script
+	 */
+	@Parameter
+	protected String preProcessingScript;
+
+	/**
+	 * Global Post Processing Script
+	 */
+	@Parameter
+	protected String postProcessingScript;
+
+	/**
+	 * On each Jmeter test Pre Processing Script
+	 */
+	@Parameter
+	protected String preTestScript;
+
+	/**
+	 * On each Jmeter test  Post Processing Script
+	 */
+	@Parameter
+	protected String postTestScript;
+
+	/**
+	 * On each Jmeter test ,add the test name on script as argument?
+	 */
+	@Parameter(defaultValue = "false")
+	protected boolean addTestNameOnScript;
+
+
 	/**
 	 * Other directories will be created by this plugin and used by JMeter
 	 */

--- a/src/main/java/com/lazerycode/jmeter/JMeterAbstractMojo.java
+++ b/src/main/java/com/lazerycode/jmeter/JMeterAbstractMojo.java
@@ -263,6 +263,12 @@ public abstract class JMeterAbstractMojo extends AbstractMojo {
 	@Parameter(defaultValue = "false")
 	protected boolean addTestNameOnScript;
 
+	/**
+	 * Place where the script files will be started.
+	 */
+	@Parameter(defaultValue = "${project.build.directory}/target")
+	protected transient File scriptDir;
+
 
 	/**
 	 * Other directories will be created by this plugin and used by JMeter

--- a/src/main/java/com/lazerycode/jmeter/JMeterAbstractMojo.java
+++ b/src/main/java/com/lazerycode/jmeter/JMeterAbstractMojo.java
@@ -266,7 +266,7 @@ public abstract class JMeterAbstractMojo extends AbstractMojo {
 	/**
 	 * Place where the script files will be started.
 	 */
-	@Parameter(defaultValue = "${project.build.directory}/target")
+	@Parameter(defaultValue = "${project.build.directory}")
 	protected transient File scriptDir;
 
 

--- a/src/main/java/com/lazerycode/jmeter/JMeterMojo.java
+++ b/src/main/java/com/lazerycode/jmeter/JMeterMojo.java
@@ -1,5 +1,6 @@
 package com.lazerycode.jmeter;
 
+import com.lazerycode.jmeter.testrunner.PrePostProcessingConfig;
 import com.lazerycode.jmeter.testrunner.TestManager;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.MojoFailureException;
@@ -45,7 +46,8 @@ public class JMeterMojo extends JMeterAbstractMojo {
 		if (null != remoteConfig) {
 			remoteConfig.setMasterPropertiesMap(pluginProperties.getMasterPropertiesMap());
 		}
-		TestManager jMeterTestManager = new TestManager(testArgs, testFilesDirectory, testFilesIncluded, testFilesExcluded, remoteConfig, suppressJMeterOutput, binDir, jMeterProcessJVMSettings);
+
+		TestManager jMeterTestManager = new TestManager(testArgs, testFilesDirectory, testFilesIncluded, testFilesExcluded, remoteConfig, suppressJMeterOutput, binDir, jMeterProcessJVMSettings,getPrePostProcessingConfig());
 		getLog().info(" ");
 		if (proxyConfig != null) {
 			getLog().info(this.proxyConfig.toString());
@@ -53,6 +55,8 @@ public class JMeterMojo extends JMeterAbstractMojo {
 		List<String> testResults = jMeterTestManager.executeTests();
 		parseTestResults(testResults);
 	}
+
+
 
 	/**
 	 * Scan JMeter result files for "error" and "failure" messages
@@ -83,5 +87,13 @@ public class JMeterMojo extends JMeterAbstractMojo {
 		if (failed) {
 			throw new MojoFailureException("There were " + totalFailureCount + " test failures.  See the JMeter logs at '" + logsDir.getAbsolutePath() + "' for details.");
 		}
+	}
+
+	/**
+	 * Construct Pre and Post Processing configuration
+	 * @return
+	 */
+	private PrePostProcessingConfig getPrePostProcessingConfig() {
+		return new PrePostProcessingConfig(preProcessingScript,postProcessingScript,preTestScript,postTestScript,addTestNameOnScript);
 	}
 }

--- a/src/main/java/com/lazerycode/jmeter/JMeterMojo.java
+++ b/src/main/java/com/lazerycode/jmeter/JMeterMojo.java
@@ -94,6 +94,6 @@ public class JMeterMojo extends JMeterAbstractMojo {
 	 * @return
 	 */
 	private PrePostProcessingConfig getPrePostProcessingConfig() {
-		return new PrePostProcessingConfig(preProcessingScript,postProcessingScript,preTestScript,postTestScript,addTestNameOnScript);
+		return new PrePostProcessingConfig(preProcessingScript,postProcessingScript,preTestScript,postTestScript,addTestNameOnScript, scriptDir);
 	}
 }

--- a/src/main/java/com/lazerycode/jmeter/testrunner/PrePostProcessingConfig.java
+++ b/src/main/java/com/lazerycode/jmeter/testrunner/PrePostProcessingConfig.java
@@ -1,0 +1,62 @@
+package com.lazerycode.jmeter.testrunner;
+
+/**
+ * Post and Pre Processing configuration
+ * The idea is to have the possibility to launch some script at each jmeter script and externally
+ * Example : jcmd JFR.start ,....
+ */
+public class PrePostProcessingConfig {
+
+	/**
+	 * Add the test name on script as argument
+	 */
+	private final boolean addTestNameOnScript;
+
+	/**
+	 * Global Pre processing Script
+	 */
+	private final String globalPreProcessingScript;
+	/**
+	 * Global Post processing Script
+	 */
+	private final String globalPostProcessingScript;
+
+	/**
+	 * Pre processing before jmeter run
+	 */
+	private final String preProcessingScript;
+	/**
+	 * Post processing after jmeter run
+	 */
+	private final String postProcessingScript;
+
+	public PrePostProcessingConfig(String globalPreProcessingScript, String globalPostProcessingScript, String preProcessingScript, String postProcessingScript,boolean addTestNameOnScript) {
+		this.globalPreProcessingScript=globalPreProcessingScript;
+		this.globalPostProcessingScript=globalPostProcessingScript;
+		this.preProcessingScript=preProcessingScript;
+		this.postProcessingScript=postProcessingScript;
+		this.addTestNameOnScript=addTestNameOnScript;
+
+	}
+
+
+	public String getGlobalPreProcessingScript() {
+		return globalPreProcessingScript;
+	}
+
+	public String getGlobalPostProcessingScript() {
+		return globalPostProcessingScript;
+	}
+
+	public String getPreProcessingScript() {
+		return preProcessingScript;
+	}
+
+	public String getPostProcessingScript() {
+		return postProcessingScript;
+	}
+
+	public boolean isAddTestNameOnScript() {
+		return addTestNameOnScript;
+	}
+}

--- a/src/main/java/com/lazerycode/jmeter/testrunner/PrePostProcessingConfig.java
+++ b/src/main/java/com/lazerycode/jmeter/testrunner/PrePostProcessingConfig.java
@@ -1,5 +1,7 @@
 package com.lazerycode.jmeter.testrunner;
 
+import java.io.File;
+
 /**
  * Post and Pre Processing configuration
  * The idea is to have the possibility to launch some script at each jmeter script and externally
@@ -29,14 +31,16 @@ public class PrePostProcessingConfig {
 	 * Post processing after jmeter run
 	 */
 	private final String postProcessingScript;
+	private final File directory;
 
-	public PrePostProcessingConfig(String globalPreProcessingScript, String globalPostProcessingScript, String preProcessingScript, String postProcessingScript,boolean addTestNameOnScript) {
+	public PrePostProcessingConfig(String globalPreProcessingScript, String globalPostProcessingScript, String preProcessingScript, String postProcessingScript, boolean addTestNameOnScript, File directory) {
 		this.globalPreProcessingScript=globalPreProcessingScript;
 		this.globalPostProcessingScript=globalPostProcessingScript;
 		this.preProcessingScript=preProcessingScript;
 		this.postProcessingScript=postProcessingScript;
 		this.addTestNameOnScript=addTestNameOnScript;
 
+		this.directory = directory;
 	}
 
 
@@ -59,4 +63,10 @@ public class PrePostProcessingConfig {
 	public boolean isAddTestNameOnScript() {
 		return addTestNameOnScript;
 	}
+
+	public File getDirectory() {
+		return directory;
+	}
+
+
 }

--- a/src/main/java/com/lazerycode/jmeter/testrunner/TestManager.java
+++ b/src/main/java/com/lazerycode/jmeter/testrunner/TestManager.java
@@ -53,7 +53,7 @@ public class TestManager extends JMeterMojo {
 	 * @throws MojoExecutionException
 	 */
 	public List<String> executeTests() throws MojoExecutionException {
-		runScript(prePostProcessingConfig.getGlobalPreProcessingScript());
+		runScript(prePostProcessingConfig.getGlobalPreProcessingScript(), prePostProcessingConfig.getDirectory());
 
 		JMeterArgumentsArray thisTestArgs = baseTestArgs;
 		List<String> tests = generateTestList();
@@ -70,7 +70,7 @@ public class TestManager extends JMeterMojo {
 			}
 			results.add(executeSingleTest(new File(testFilesDirectory, file), thisTestArgs));
 		}
-		runScript(prePostProcessingConfig.getGlobalPostProcessingScript());
+		runScript(prePostProcessingConfig.getGlobalPostProcessingScript(), prePostProcessingConfig.getDirectory());
 		return results;
 	}
 
@@ -106,7 +106,7 @@ public class TestManager extends JMeterMojo {
 				commandStr.append(" ").append(test.getName().toString());
 			}
 
-			runScript(commandStr.toString());
+			runScript(commandStr.toString(), prePostProcessingConfig.getDirectory());
 
 			final Process process = JMeterProcessBuilder.startProcess();
 			BufferedReader br = new BufferedReader(new InputStreamReader(process.getInputStream()));
@@ -135,7 +135,7 @@ public class TestManager extends JMeterMojo {
 			if(prePostProcessingConfig.isAddTestNameOnScript()){
 				commandStr.append(" ").append(test.getName().toString());
 			}
-			runScript(commandStr.toString());
+			runScript(commandStr.toString(), prePostProcessingConfig.getDirectory());
 
 		}
 		return testArgs.getResultsLogFileName();
@@ -168,11 +168,11 @@ public class TestManager extends JMeterMojo {
 	}
 
 
-	private void runScript(String command)  {
+	private void runScript(String command, File dir)  {
 		getLog().debug("Call script : " + command);
 		try {
 			if(command!=null||!command.isEmpty()) {
-				Process process= Runtime.getRuntime().exec(command.split(" "));
+				Process process= Runtime.getRuntime().exec(command.split(" "),null,dir);
 				BufferedReader reader =null;
 				try{
 					reader = new BufferedReader(new InputStreamReader(process.getInputStream()));


### PR DESCRIPTION
I need to launch simple script before and atfer launching each jmeter file/test.

By example I get a JFR dump during the jmeter test as 
jcmd JFR.start DTCCReport.jmx

plugin configuration sample is : 
 <preProcessingScript>${basedir}/src/test/jmeter/startjcmd.sh global  </preProcessingScript>
 <postProcessingScript>${basedir}/src/test/jmeter/stopjcmd.sh global</postProcessingScript>
 <preTestScript>${basedir}/src/test/jmeter/startjcmd.sh</preTestScript>
 <postTestScript>${basedir}/src/test/jmeter/stopjcmd.sh</postTestScript>
 <addTestNameOnScript>true</addTestNameOnScript>
