### PR TITLE
Passing  a string of jmeter files to maven

### DIFF
--- a/src/main/java/com/lazerycode/jmeter/testrunner/JMeterFilesScaner.java
+++ b/src/main/java/com/lazerycode/jmeter/testrunner/JMeterFilesScaner.java
@@ -1,0 +1,76 @@
+package com.lazerycode.jmeter.testrunner;
+
+import java.io.File;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import org.apache.tools.ant.DirectoryScanner;
+
+/**
+ * <pre>
+ * 
+ * Scan Project directories for JMeter Test Files according to includes and excludes
+ * 
+ *  If "includes" only has one row with separated values, 
+ *  	then a new List is build with those values as rows
+ *  	and the jmx extension will be added if it's needed
+ * 
+ * </pre>
+ * 
+ * @author s2o
+ */
+public class JMeterFilesScaner {
+
+	private static final String ALL_JMX = "**/*.jmx";
+
+	private static final String COMMA = ",";
+
+	private static final String JMX = ".jmx";
+
+	private final File testFilesDirectory;
+	private final List<String> testFilesIncluded;
+	private final List<String> testFilesExcluded;
+
+	public JMeterFilesScaner(File testFilesDirectory, List<String> testFilesIncluded, List<String> testFilesExcluded) {
+		this.testFilesDirectory = testFilesDirectory;
+		this.testFilesIncluded = testFilesIncluded;
+		this.testFilesExcluded = testFilesExcluded;
+	}
+
+	/**
+	 * Get the list of jMeter files to be executed
+	 * 
+	 * @return
+	 */
+	protected List<String> generateTestList() {
+		List<String> jmeterTestFiles = new ArrayList<String>();
+		DirectoryScanner scanner = new DirectoryScanner();
+		scanner.setBasedir(this.testFilesDirectory);
+
+		if (testFilesIncluded != null && testFilesIncluded.size() == 1 && testFilesIncluded.get(0).contains(COMMA)) {
+			String[] jMeterSuites = testFilesIncluded.get(0).split(COMMA);
+			int indexFile = 0;
+			for (String file : jMeterSuites) {
+				if (!file.trim().endsWith(JMX)) {
+					file = file.trim().concat(JMX);
+				}
+				jMeterSuites[indexFile++] = file;
+			}
+			scanner.setIncludes(jMeterSuites);
+		} else {
+			scanner.setIncludes(this.testFilesIncluded == null ? new String[] { ALL_JMX } : this.testFilesIncluded
+					.toArray(new String[jmeterTestFiles.size()]));
+		}
+
+		if (this.testFilesExcluded != null) {
+			scanner.setExcludes(this.testFilesExcluded.toArray(new String[testFilesExcluded.size()]));
+		}
+		scanner.scan();
+		final List<String> includedFiles = Arrays.asList(scanner.getIncludedFiles());
+		jmeterTestFiles.addAll(includedFiles);
+
+		return jmeterTestFiles;
+	}
+
+}

--- a/src/main/java/com/lazerycode/jmeter/testrunner/TestManager.java
+++ b/src/main/java/com/lazerycode/jmeter/testrunner/TestManager.java
@@ -1,22 +1,21 @@
 package com.lazerycode.jmeter.testrunner;
 
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+import org.apache.maven.plugin.MojoExecutionException;
+
 import com.lazerycode.jmeter.JMeterMojo;
 import com.lazerycode.jmeter.UtilityFunctions;
 import com.lazerycode.jmeter.configuration.JMeterArgumentsArray;
 import com.lazerycode.jmeter.configuration.JMeterProcessJVMSettings;
 import com.lazerycode.jmeter.configuration.RemoteArgumentsArrayBuilder;
 import com.lazerycode.jmeter.configuration.RemoteConfiguration;
-import org.apache.maven.plugin.MojoExecutionException;
-import org.apache.tools.ant.DirectoryScanner;
-
-import java.io.BufferedReader;
-import java.io.File;
-import java.io.IOException;
-import java.io.InputStreamReader;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.List;
 
 /**
  * TestManager encapsulates functions that gather JMeter Test files and execute the tests
@@ -32,7 +31,9 @@ public class TestManager extends JMeterMojo {
 	private final RemoteConfiguration remoteServerConfiguration;
 	private final JMeterProcessJVMSettings jMeterProcessJVMSettings;
 
-	public TestManager(JMeterArgumentsArray baseTestArgs, File testFilesDirectory, List<String> testFilesIncluded, List<String> testFilesExcluded, RemoteConfiguration remoteServerConfiguration, boolean suppressJMeterOutput, File binDir, JMeterProcessJVMSettings jMeterProcessJVMSettings) {
+	public TestManager(JMeterArgumentsArray baseTestArgs, File testFilesDirectory, List<String> testFilesIncluded,
+			List<String> testFilesExcluded, RemoteConfiguration remoteServerConfiguration,
+			boolean suppressJMeterOutput, File binDir, JMeterProcessJVMSettings jMeterProcessJVMSettings) {
 		this.binDir = binDir;
 		this.baseTestArgs = baseTestArgs;
 		this.testFilesDirectory = testFilesDirectory;
@@ -51,15 +52,19 @@ public class TestManager extends JMeterMojo {
 	 */
 	public List<String> executeTests() throws MojoExecutionException {
 		JMeterArgumentsArray thisTestArgs = baseTestArgs;
-		List<String> tests = generateTestList();
+		List<String> tests = new JMeterFilesScaner(testFilesDirectory, testFilesIncluded, testFilesExcluded)
+				.generateTestList();
+		getLog().info(" jMeter files:" + tests);
 		List<String> results = new ArrayList<String>();
 		for (String file : tests) {
 			if (remoteServerConfiguration != null) {
-				if ((remoteServerConfiguration.isStartServersBeforeTests() && tests.get(0).equals(file)) || remoteServerConfiguration.isStartAndStopServersForEachTest()) {
+				if ((remoteServerConfiguration.isStartServersBeforeTests() && tests.get(0).equals(file))
+						|| remoteServerConfiguration.isStartAndStopServersForEachTest()) {
 					thisTestArgs.setRemoteStart();
 					thisTestArgs.setRemoteStartServerList(remoteServerConfiguration.getServerList());
 				}
-				if ((remoteServerConfiguration.isStopServersAfterTests() && tests.get(tests.size() - 1).equals(file)) || remoteServerConfiguration.isStartAndStopServersForEachTest()) {
+				if ((remoteServerConfiguration.isStopServersAfterTests() && tests.get(tests.size() - 1).equals(file))
+						|| remoteServerConfiguration.isStartAndStopServersForEachTest()) {
 					thisTestArgs.setRemoteStop();
 				}
 			}
@@ -68,27 +73,30 @@ public class TestManager extends JMeterMojo {
 		return results;
 	}
 
-	//=============================================================================================
+	// =============================================================================================
 
 	/**
-	 * Executes a single JMeter test by building up a list of command line
-	 * parameters to pass to JMeter.start().
+	 * Executes a single JMeter test by building up a list of command line parameters to pass to JMeter.start().
 	 *
-	 * @param test JMeter test XML
+	 * @param test
+	 *            JMeter test XML
 	 * @return the report file names.
-	 * @throws org.apache.maven.plugin.MojoExecutionException Exception
+	 * @throws org.apache.maven.plugin.MojoExecutionException
+	 *             Exception
 	 */
 	@SuppressWarnings("ResultOfMethodCallIgnored")
 	private String executeSingleTest(File test, JMeterArgumentsArray testArgs) throws MojoExecutionException {
 		getLog().info(" ");
 		testArgs.setTestFile(test);
-		//Delete results file if it already exists
+		// Delete results file if it already exists
 		new File(testArgs.getResultsLogFileName()).delete();
 		List<String> argumentsArray = testArgs.buildArgumentsArray();
 		argumentsArray.addAll(buildRemoteArgs(remoteServerConfiguration));
-		getLog().debug("JMeter is called with the following command line arguments: " + UtilityFunctions.humanReadableCommandLineOutput(argumentsArray));
+		getLog().debug(
+				"JMeter is called with the following command line arguments: "
+						+ UtilityFunctions.humanReadableCommandLineOutput(argumentsArray));
 		getLog().info("Executing test: " + test.getName());
-		//Start the test.
+		// Start the test.
 		JMeterProcessBuilder JMeterProcessBuilder = new JMeterProcessBuilder(jMeterProcessJVMSettings);
 		JMeterProcessBuilder.setWorkingDirectory(binDir);
 		JMeterProcessBuilder.addArguments(argumentsArray);
@@ -123,24 +131,5 @@ public class TestManager extends JMeterMojo {
 			return Collections.emptyList();
 		}
 		return new RemoteArgumentsArrayBuilder().buildRemoteArgumentsArray(remoteConfig.getMasterPropertiesMap());
-	}
-
-	/**
-	 * Scan Project directories for JMeter Test Files according to includes and excludes
-	 *
-	 * @return found JMeter tests
-	 */
-	private List<String> generateTestList() {
-		List<String> jmeterTestFiles = new ArrayList<String>();
-		DirectoryScanner scanner = new DirectoryScanner();
-		scanner.setBasedir(this.testFilesDirectory);
-		scanner.setIncludes(this.testFilesIncluded == null ? new String[]{"**/*.jmx"} : this.testFilesIncluded.toArray(new String[jmeterTestFiles.size()]));
-		if (this.testFilesExcluded != null) {
-			scanner.setExcludes(this.testFilesExcluded.toArray(new String[testFilesExcluded.size()]));
-		}
-		scanner.scan();
-		final List<String> includedFiles = Arrays.asList(scanner.getIncludedFiles());
-		jmeterTestFiles.addAll(includedFiles);
-		return jmeterTestFiles;
 	}
 }

--- a/src/test/java/com/lazerycode/jmeter/testrunner/JMeterFilesScanerTest.java
+++ b/src/test/java/com/lazerycode/jmeter/testrunner/JMeterFilesScanerTest.java
@@ -1,0 +1,68 @@
+package com.lazerycode.jmeter.testrunner;
+
+import static org.hamcrest.core.Is.is;
+import static org.hamcrest.core.IsEqual.equalTo;
+import static org.junit.Assert.assertThat;
+
+import java.io.File;
+import java.net.URISyntaxException;
+import java.net.URL;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.junit.Before;
+import org.junit.Test;
+
+public class JMeterFilesScanerTest {
+
+	private final URL testFilesDirectoryURL = this.getClass().getResource("/");
+	private File testFilesDirectory;
+
+	@Before
+	public void init() {
+		try {
+			testFilesDirectory = new File(testFilesDirectoryURL.toURI());
+		} catch (URISyntaxException e) {
+			e.printStackTrace();
+		}
+	}
+
+	@Test
+	public void testNull() {
+		List<String> testFilesIncluded = null;
+		List<String> testFilesExcluded = new ArrayList<String>();
+		List<String> testsFiles = new JMeterFilesScaner(testFilesDirectory, testFilesIncluded, testFilesExcluded)
+				.generateTestList();
+		assertThat(testsFiles.size(), is(equalTo(2)));
+	}
+
+	@Test
+	public void testEmpty() {
+		List<String> testFilesIncluded = new ArrayList<String>();
+		List<String> testFilesExcluded = new ArrayList<String>();
+		List<String> testsFiles = new JMeterFilesScaner(testFilesDirectory, testFilesIncluded, testFilesExcluded)
+				.generateTestList();
+		assertThat(testsFiles.size(), is(equalTo(0)));
+	}
+
+	@Test
+	public void testFirstRow() {
+		List<String> testFilesIncluded = new ArrayList<String>();
+		List<String> testFilesExcluded = new ArrayList<String>();
+		testFilesIncluded.add("test.jmx,test2.jmx");
+		List<String> testsFiles = new JMeterFilesScaner(testFilesDirectory, testFilesIncluded, testFilesExcluded)
+				.generateTestList();
+		assertThat(testsFiles.size(), is(equalTo(2)));
+	}
+
+	@Test
+	public void testFirstRow_withOutExtension() {
+		List<String> testFilesIncluded = new ArrayList<String>();
+		List<String> testFilesExcluded = new ArrayList<String>();
+		testFilesIncluded.add("test,test2");
+		List<String> testsFiles = new JMeterFilesScaner(testFilesDirectory, testFilesIncluded, testFilesExcluded)
+				.generateTestList();
+		assertThat(testsFiles.size(), is(equalTo(2)));
+	}
+
+}

--- a/src/test/resources/test2.jmx
+++ b/src/test/resources/test2.jmx
@@ -1,0 +1,383 @@
+<jmeterTestPlan version="1.2" properties="1.8">
+    <hashTree>
+        <TestPlan guiclass="TestPlanGui" testclass="TestPlan" testname="Test Plan" enabled="true">
+            <elementProp name="TestPlan.user_defined_variables" elementType="Arguments" guiclass="ArgumentsPanel" testclass="Arguments" testname="User Defined Variables" enabled="true">
+                <collectionProp name="Arguments.arguments"/>
+            </elementProp>
+            <stringProp name="TestPlan.user_define_classpath"></stringProp>
+            <boolProp name="TestPlan.serialize_threadgroups">false</boolProp>
+            <boolProp name="TestPlan.functional_mode">false</boolProp>
+            <stringProp name="TestPlan.comments"></stringProp>
+        </TestPlan>
+        <hashTree>
+            <ThreadGroup guiclass="ThreadGroupGui" testclass="ThreadGroup" testname="Thread Group" enabled="true">
+                <longProp name="ThreadGroup.start_time">1157151632000</longProp>
+                <stringProp name="ThreadGroup.delay"></stringProp>
+                <stringProp name="ThreadGroup.duration"></stringProp>
+                <stringProp name="ThreadGroup.num_threads">5</stringProp>
+                <boolProp name="ThreadGroup.scheduler">false</boolProp>
+                <elementProp name="ThreadGroup.main_controller" elementType="LoopController" guiclass="LoopControlPanel" testclass="LoopController" testname="Loop Controller" enabled="true">
+                    <stringProp name="LoopController.loops">5</stringProp>
+                    <boolProp name="LoopController.continue_forever">false</boolProp>
+                </elementProp>
+                <longProp name="ThreadGroup.end_time">1157151632000</longProp>
+                <stringProp name="ThreadGroup.on_sample_error">continue</stringProp>
+                <stringProp name="ThreadGroup.ramp_time">1</stringProp>
+            </ThreadGroup>
+            <hashTree>
+                <HeaderManager guiclass="HeaderPanel" testclass="HeaderManager" testname="HTTP Header Manager" enabled="true">
+                    <collectionProp name="HeaderManager.headers">
+                        <elementProp name="" elementType="Header">
+                            <stringProp name="Header.value">Mozilla/5.0 (Macintosh; U; PPC Mac OS X; en) AppleWebKit/XX (KHTML, like Gecko) Safari/YY</stringProp>
+                            <stringProp name="Header.name">User-Agent</stringProp>
+                        </elementProp>
+                    </collectionProp>
+                </HeaderManager>
+                <hashTree/>
+                <ConfigTestElement guiclass="HttpDefaultsGui" testclass="ConfigTestElement" testname="HTTP Request Defaults" enabled="true">
+                    <stringProp name="HTTPSampler.path"></stringProp>
+                    <stringProp name="HTTPSampler.domain">www.digg.com</stringProp>
+                    <stringProp name="HTTPSampler.protocol"></stringProp>
+                    <elementProp name="HTTPsampler.Arguments" elementType="Arguments" guiclass="HTTPArgumentsPanel" testclass="Arguments" testname="User Defined Variables" enabled="true">
+                        <collectionProp name="Arguments.arguments"/>
+                    </elementProp>
+                    <stringProp name="HTTPSampler.port">80</stringProp>
+                </ConfigTestElement>
+                <hashTree/>
+                <HTTPSampler guiclass="HttpTestSampleGui" testclass="HTTPSampler" testname="Digg root page" enabled="true">
+                    <stringProp name="HTTPSampler.path">/</stringProp>
+                    <stringProp name="HTTPSampler.method">GET</stringProp>
+                    <boolProp name="HTTPSampler.use_keepalive">true</boolProp>
+                    <stringProp name="HTTPSampler.protocol">http</stringProp>
+                    <boolProp name="HTTPSampler.follow_redirects">false</boolProp>
+                    <stringProp name="HTTPSampler.port">80</stringProp>
+                    <elementProp name="HTTPsampler.Arguments" elementType="Arguments" guiclass="HTTPArgumentsPanel" testclass="Arguments" enabled="true">
+                        <collectionProp name="Arguments.arguments"/>
+                    </elementProp>
+                    <stringProp name="HTTPSampler.mimetype"></stringProp>
+                    <stringProp name="HTTPSampler.FILE_FIELD"></stringProp>
+                    <stringProp name="HTTPSampler.monitor">false</stringProp>
+                    <stringProp name="HTTPSampler.domain">www.digg.com</stringProp>
+                    <stringProp name="HTTPSampler.FILE_NAME"></stringProp>
+                    <boolProp name="HTTPSampler.auto_redirects">false</boolProp>
+                </HTTPSampler>
+                <hashTree/>
+                <HTTPSampler guiclass="HttpTestSampleGui" testclass="HTTPSampler" testname="Search for Apple" enabled="true">
+                    <stringProp name="HTTPSampler.path">/search</stringProp>
+                    <stringProp name="HTTPSampler.method">GET</stringProp>
+                    <boolProp name="HTTPSampler.use_keepalive">true</boolProp>
+                    <stringProp name="HTTPSampler.protocol">http</stringProp>
+                    <boolProp name="HTTPSampler.follow_redirects">false</boolProp>
+                    <stringProp name="HTTPSampler.port">80</stringProp>
+                    <elementProp name="HTTPsampler.Arguments" elementType="Arguments" guiclass="HTTPArgumentsPanel" testclass="Arguments" enabled="true">
+                        <collectionProp name="Arguments.arguments">
+                            <elementProp name="" elementType="HTTPArgument">
+                                <stringProp name="Argument.metadata">=</stringProp>
+                                <stringProp name="Argument.value">Apple</stringProp>
+                                <boolProp name="HTTPArgument.use_equals">true</boolProp>
+                                <stringProp name="Argument.name">s</stringProp>
+                                <boolProp name="HTTPArgument.always_encode">false</boolProp>
+                            </elementProp>
+                        </collectionProp>
+                    </elementProp>
+                    <stringProp name="HTTPSampler.mimetype"></stringProp>
+                    <stringProp name="HTTPSampler.FILE_FIELD"></stringProp>
+                    <stringProp name="HTTPSampler.monitor">false</stringProp>
+                    <stringProp name="HTTPSampler.domain">www.digg.com</stringProp>
+                    <stringProp name="HTTPSampler.FILE_NAME"></stringProp>
+                    <boolProp name="HTTPSampler.auto_redirects">false</boolProp>
+                </HTTPSampler>
+                <hashTree/>
+                <HTTPSampler guiclass="HttpTestSampleGui" testclass="HTTPSampler" testname="Search for Microsoft" enabled="true">
+                    <stringProp name="HTTPSampler.path">/search</stringProp>
+                    <stringProp name="HTTPSampler.method">GET</stringProp>
+                    <boolProp name="HTTPSampler.use_keepalive">true</boolProp>
+                    <stringProp name="HTTPSampler.protocol">http</stringProp>
+                    <boolProp name="HTTPSampler.follow_redirects">false</boolProp>
+                    <stringProp name="HTTPSampler.port">80</stringProp>
+                    <elementProp name="HTTPsampler.Arguments" elementType="Arguments" guiclass="HTTPArgumentsPanel" testclass="Arguments" enabled="true">
+                        <collectionProp name="Arguments.arguments">
+                            <elementProp name="" elementType="HTTPArgument">
+                                <stringProp name="Argument.metadata">=</stringProp>
+                                <stringProp name="Argument.value">Microsoft</stringProp>
+                                <boolProp name="HTTPArgument.use_equals">true</boolProp>
+                                <stringProp name="Argument.name">s</stringProp>
+                                <boolProp name="HTTPArgument.always_encode">false</boolProp>
+                            </elementProp>
+                        </collectionProp>
+                    </elementProp>
+                    <stringProp name="HTTPSampler.mimetype"></stringProp>
+                    <stringProp name="HTTPSampler.FILE_FIELD"></stringProp>
+                    <stringProp name="HTTPSampler.monitor">false</stringProp>
+                    <stringProp name="HTTPSampler.domain">www.digg.com</stringProp>
+                    <stringProp name="HTTPSampler.FILE_NAME"></stringProp>
+                    <boolProp name="HTTPSampler.auto_redirects">false</boolProp>
+                </HTTPSampler>
+                <hashTree/>
+                <HTTPSampler guiclass="HttpTestSampleGui" testclass="HTTPSampler" testname="Search for Video" enabled="true">
+                    <stringProp name="HTTPSampler.path">/search</stringProp>
+                    <stringProp name="HTTPSampler.method">GET</stringProp>
+                    <boolProp name="HTTPSampler.use_keepalive">true</boolProp>
+                    <stringProp name="HTTPSampler.protocol">http</stringProp>
+                    <boolProp name="HTTPSampler.follow_redirects">false</boolProp>
+                    <stringProp name="HTTPSampler.port">80</stringProp>
+                    <elementProp name="HTTPsampler.Arguments" elementType="Arguments" guiclass="HTTPArgumentsPanel" testclass="Arguments" enabled="true">
+                        <collectionProp name="Arguments.arguments">
+                            <elementProp name="" elementType="HTTPArgument">
+                                <stringProp name="Argument.metadata">=</stringProp>
+                                <stringProp name="Argument.value">video</stringProp>
+                                <boolProp name="HTTPArgument.use_equals">true</boolProp>
+                                <stringProp name="Argument.name">s</stringProp>
+                                <boolProp name="HTTPArgument.always_encode">false</boolProp>
+                            </elementProp>
+                        </collectionProp>
+                    </elementProp>
+                    <stringProp name="HTTPSampler.mimetype"></stringProp>
+                    <stringProp name="HTTPSampler.FILE_FIELD"></stringProp>
+                    <stringProp name="HTTPSampler.monitor">false</stringProp>
+                    <stringProp name="HTTPSampler.domain">www.digg.com</stringProp>
+                    <stringProp name="HTTPSampler.FILE_NAME"></stringProp>
+                    <boolProp name="HTTPSampler.auto_redirects">false</boolProp>
+                </HTTPSampler>
+                <hashTree/>
+                <HTTPSampler guiclass="HttpTestSampleGui" testclass="HTTPSampler" testname="View Gaming" enabled="true">
+                    <stringProp name="HTTPSampler.path">/view/gaming</stringProp>
+                    <stringProp name="HTTPSampler.method">GET</stringProp>
+                    <boolProp name="HTTPSampler.use_keepalive">true</boolProp>
+                    <stringProp name="HTTPSampler.protocol">http</stringProp>
+                    <boolProp name="HTTPSampler.follow_redirects">false</boolProp>
+                    <stringProp name="HTTPSampler.port">80</stringProp>
+                    <elementProp name="HTTPsampler.Arguments" elementType="Arguments" guiclass="HTTPArgumentsPanel" testclass="Arguments" enabled="true">
+                        <collectionProp name="Arguments.arguments"/>
+                    </elementProp>
+                    <stringProp name="HTTPSampler.mimetype"></stringProp>
+                    <stringProp name="HTTPSampler.FILE_FIELD"></stringProp>
+                    <stringProp name="HTTPSampler.monitor">false</stringProp>
+                    <stringProp name="HTTPSampler.domain">www.digg.com</stringProp>
+                    <stringProp name="HTTPSampler.FILE_NAME"></stringProp>
+                    <boolProp name="HTTPSampler.auto_redirects">false</boolProp>
+                </HTTPSampler>
+                <hashTree/>
+                <HTTPSampler guiclass="HttpTestSampleGui" testclass="HTTPSampler" testname="View All" enabled="true">
+                    <stringProp name="HTTPSampler.path">/view/all</stringProp>
+                    <stringProp name="HTTPSampler.method">GET</stringProp>
+                    <boolProp name="HTTPSampler.use_keepalive">true</boolProp>
+                    <stringProp name="HTTPSampler.protocol">http</stringProp>
+                    <boolProp name="HTTPSampler.follow_redirects">false</boolProp>
+                    <stringProp name="HTTPSampler.port">80</stringProp>
+                    <elementProp name="HTTPsampler.Arguments" elementType="Arguments" guiclass="HTTPArgumentsPanel" testclass="Arguments" enabled="true">
+                        <collectionProp name="Arguments.arguments"/>
+                    </elementProp>
+                    <stringProp name="HTTPSampler.mimetype"></stringProp>
+                    <stringProp name="HTTPSampler.FILE_FIELD"></stringProp>
+                    <stringProp name="HTTPSampler.monitor">false</stringProp>
+                    <stringProp name="HTTPSampler.domain">www.digg.com</stringProp>
+                    <stringProp name="HTTPSampler.FILE_NAME"></stringProp>
+                    <boolProp name="HTTPSampler.auto_redirects">false</boolProp>
+                </HTTPSampler>
+                <hashTree/>
+                <HTTPSampler guiclass="HttpTestSampleGui" testclass="HTTPSampler" testname="View Technology" enabled="true">
+                    <stringProp name="HTTPSampler.path">/view/technology</stringProp>
+                    <stringProp name="HTTPSampler.method">GET</stringProp>
+                    <boolProp name="HTTPSampler.use_keepalive">true</boolProp>
+                    <stringProp name="HTTPSampler.protocol">http</stringProp>
+                    <boolProp name="HTTPSampler.follow_redirects">false</boolProp>
+                    <stringProp name="HTTPSampler.port">80</stringProp>
+                    <elementProp name="HTTPsampler.Arguments" elementType="Arguments" guiclass="HTTPArgumentsPanel" testclass="Arguments" enabled="true">
+                        <collectionProp name="Arguments.arguments"/>
+                    </elementProp>
+                    <stringProp name="HTTPSampler.mimetype"></stringProp>
+                    <stringProp name="HTTPSampler.FILE_FIELD"></stringProp>
+                    <stringProp name="HTTPSampler.monitor">false</stringProp>
+                    <stringProp name="HTTPSampler.domain">www.digg.com</stringProp>
+                    <stringProp name="HTTPSampler.FILE_NAME"></stringProp>
+                    <boolProp name="HTTPSampler.auto_redirects">false</boolProp>
+                </HTTPSampler>
+                <hashTree/>
+                <HTTPSampler guiclass="HttpTestSampleGui" testclass="HTTPSampler" testname="View Science" enabled="true">
+                    <stringProp name="HTTPSampler.path">/view/science</stringProp>
+                    <stringProp name="HTTPSampler.method">GET</stringProp>
+                    <boolProp name="HTTPSampler.use_keepalive">true</boolProp>
+                    <stringProp name="HTTPSampler.protocol">http</stringProp>
+                    <boolProp name="HTTPSampler.follow_redirects">false</boolProp>
+                    <stringProp name="HTTPSampler.port">80</stringProp>
+                    <elementProp name="HTTPsampler.Arguments" elementType="Arguments" guiclass="HTTPArgumentsPanel" testclass="Arguments" enabled="true">
+                        <collectionProp name="Arguments.arguments"/>
+                    </elementProp>
+                    <stringProp name="HTTPSampler.mimetype"></stringProp>
+                    <stringProp name="HTTPSampler.FILE_FIELD"></stringProp>
+                    <stringProp name="HTTPSampler.monitor">false</stringProp>
+                    <stringProp name="HTTPSampler.domain">www.digg.com</stringProp>
+                    <stringProp name="HTTPSampler.FILE_NAME"></stringProp>
+                    <boolProp name="HTTPSampler.auto_redirects">false</boolProp>
+                </HTTPSampler>
+                <hashTree/>
+                <HTTPSampler guiclass="HttpTestSampleGui" testclass="HTTPSampler" testname="View Business" enabled="true">
+                    <stringProp name="HTTPSampler.path">/view/world_business</stringProp>
+                    <stringProp name="HTTPSampler.method">GET</stringProp>
+                    <boolProp name="HTTPSampler.use_keepalive">true</boolProp>
+                    <stringProp name="HTTPSampler.protocol">http</stringProp>
+                    <boolProp name="HTTPSampler.follow_redirects">false</boolProp>
+                    <stringProp name="HTTPSampler.port">80</stringProp>
+                    <elementProp name="HTTPsampler.Arguments" elementType="Arguments" guiclass="HTTPArgumentsPanel" testclass="Arguments" enabled="true">
+                        <collectionProp name="Arguments.arguments"/>
+                    </elementProp>
+                    <stringProp name="HTTPSampler.mimetype"></stringProp>
+                    <stringProp name="HTTPSampler.FILE_FIELD"></stringProp>
+                    <stringProp name="HTTPSampler.monitor">false</stringProp>
+                    <stringProp name="HTTPSampler.domain">www.digg.com</stringProp>
+                    <stringProp name="HTTPSampler.FILE_NAME"></stringProp>
+                    <boolProp name="HTTPSampler.auto_redirects">false</boolProp>
+                </HTTPSampler>
+                <hashTree/>
+                <HTTPSampler guiclass="HttpTestSampleGui" testclass="HTTPSampler" testname="View Sports" enabled="true">
+                    <stringProp name="HTTPSampler.path">/view/sports</stringProp>
+                    <stringProp name="HTTPSampler.method">GET</stringProp>
+                    <boolProp name="HTTPSampler.use_keepalive">true</boolProp>
+                    <stringProp name="HTTPSampler.protocol">http</stringProp>
+                    <boolProp name="HTTPSampler.follow_redirects">false</boolProp>
+                    <stringProp name="HTTPSampler.port">80</stringProp>
+                    <elementProp name="HTTPsampler.Arguments" elementType="Arguments" guiclass="HTTPArgumentsPanel" testclass="Arguments" enabled="true">
+                        <collectionProp name="Arguments.arguments"/>
+                    </elementProp>
+                    <stringProp name="HTTPSampler.mimetype"></stringProp>
+                    <stringProp name="HTTPSampler.FILE_FIELD"></stringProp>
+                    <stringProp name="HTTPSampler.monitor">false</stringProp>
+                    <stringProp name="HTTPSampler.domain">www.digg.com</stringProp>
+                    <stringProp name="HTTPSampler.FILE_NAME"></stringProp>
+                    <boolProp name="HTTPSampler.auto_redirects">false</boolProp>
+                </HTTPSampler>
+                <hashTree/>
+                <HTTPSampler guiclass="HttpTestSampleGui" testclass="HTTPSampler" testname="View Videos" enabled="true">
+                    <stringProp name="HTTPSampler.path">/view/videos</stringProp>
+                    <stringProp name="HTTPSampler.method">GET</stringProp>
+                    <boolProp name="HTTPSampler.use_keepalive">true</boolProp>
+                    <stringProp name="HTTPSampler.protocol">http</stringProp>
+                    <boolProp name="HTTPSampler.follow_redirects">false</boolProp>
+                    <stringProp name="HTTPSampler.port">80</stringProp>
+                    <elementProp name="HTTPsampler.Arguments" elementType="Arguments" guiclass="HTTPArgumentsPanel" testclass="Arguments" enabled="true">
+                        <collectionProp name="Arguments.arguments"/>
+                    </elementProp>
+                    <stringProp name="HTTPSampler.mimetype"></stringProp>
+                    <stringProp name="HTTPSampler.FILE_FIELD"></stringProp>
+                    <stringProp name="HTTPSampler.monitor">false</stringProp>
+                    <stringProp name="HTTPSampler.domain">www.digg.com</stringProp>
+                    <stringProp name="HTTPSampler.FILE_NAME"></stringProp>
+                    <boolProp name="HTTPSampler.auto_redirects">false</boolProp>
+                </HTTPSampler>
+                <hashTree/>
+                <HTTPSampler guiclass="HttpTestSampleGui" testclass="HTTPSampler" testname="View Entertainment" enabled="true">
+                    <stringProp name="HTTPSampler.path">/view/entertainment</stringProp>
+                    <stringProp name="HTTPSampler.method">GET</stringProp>
+                    <boolProp name="HTTPSampler.use_keepalive">true</boolProp>
+                    <stringProp name="HTTPSampler.protocol">http</stringProp>
+                    <boolProp name="HTTPSampler.follow_redirects">false</boolProp>
+                    <stringProp name="HTTPSampler.port">80</stringProp>
+                    <elementProp name="HTTPsampler.Arguments" elementType="Arguments" guiclass="HTTPArgumentsPanel" testclass="Arguments" enabled="true">
+                        <collectionProp name="Arguments.arguments"/>
+                    </elementProp>
+                    <stringProp name="HTTPSampler.mimetype"></stringProp>
+                    <stringProp name="HTTPSampler.FILE_FIELD"></stringProp>
+                    <stringProp name="HTTPSampler.monitor">false</stringProp>
+                    <stringProp name="HTTPSampler.domain">www.digg.com</stringProp>
+                    <stringProp name="HTTPSampler.FILE_NAME"></stringProp>
+                    <boolProp name="HTTPSampler.auto_redirects">false</boolProp>
+                </HTTPSampler>
+                <hashTree/>
+                <ResultCollector guiclass="ViewResultsFullVisualizer" testclass="ResultCollector" testname="View Results Tree" enabled="true">
+                    <objProp>
+                        <value class="SampleSaveConfiguration">
+                            <time>true</time>
+                            <latency>true</latency>
+                            <timestamp>true</timestamp>
+                            <success>true</success>
+                            <label>true</label>
+                            <code>true</code>
+                            <message>true</message>
+                            <threadName>true</threadName>
+                            <dataType>true</dataType>
+                            <encoding>false</encoding>
+                            <assertions>true</assertions>
+                            <subresults>true</subresults>
+                            <responseData>false</responseData>
+                            <samplerData>false</samplerData>
+                            <xml>true</xml>
+                            <fieldNames>false</fieldNames>
+                            <responseHeaders>false</responseHeaders>
+                            <requestHeaders>false</requestHeaders>
+                            <responseDataOnError>false</responseDataOnError>
+                            <saveAssertionResultsFailureMessage>true</saveAssertionResultsFailureMessage>
+                            <assertionsResultsToSave>0</assertionsResultsToSave>
+                        </value>
+                        <name>saveConfig</name>
+                    </objProp>
+                    <stringProp name="filename"></stringProp>
+                    <boolProp name="ResultCollector.error_logging">false</boolProp>
+                </ResultCollector>
+                <hashTree/>
+                <ResultCollector guiclass="GraphVisualizer" testclass="ResultCollector" testname="Graph Results" enabled="true">
+                    <objProp>
+                        <value class="SampleSaveConfiguration">
+                            <time>true</time>
+                            <latency>true</latency>
+                            <timestamp>true</timestamp>
+                            <success>true</success>
+                            <label>true</label>
+                            <code>true</code>
+                            <message>true</message>
+                            <threadName>true</threadName>
+                            <dataType>true</dataType>
+                            <encoding>false</encoding>
+                            <assertions>true</assertions>
+                            <subresults>true</subresults>
+                            <responseData>false</responseData>
+                            <samplerData>false</samplerData>
+                            <xml>false</xml>
+                            <fieldNames>false</fieldNames>
+                            <responseHeaders>false</responseHeaders>
+                            <requestHeaders>false</requestHeaders>
+                            <responseDataOnError>false</responseDataOnError>
+                            <saveAssertionResultsFailureMessage>false</saveAssertionResultsFailureMessage>
+                            <assertionsResultsToSave>0</assertionsResultsToSave>
+                        </value>
+                        <name>saveConfig</name>
+                    </objProp>
+                    <stringProp name="filename"></stringProp>
+                    <boolProp name="ResultCollector.error_logging">false</boolProp>
+                </ResultCollector>
+                <hashTree/>
+                <ResultCollector guiclass="SummaryReport" testclass="ResultCollector" testname="Summary Report" enabled="true">
+                    <objProp>
+                        <value class="SampleSaveConfiguration">
+                            <time>true</time>
+                            <latency>true</latency>
+                            <timestamp>true</timestamp>
+                            <success>true</success>
+                            <label>true</label>
+                            <code>true</code>
+                            <message>true</message>
+                            <threadName>true</threadName>
+                            <dataType>true</dataType>
+                            <encoding>false</encoding>
+                            <assertions>true</assertions>
+                            <subresults>true</subresults>
+                            <responseData>false</responseData>
+                            <samplerData>false</samplerData>
+                            <xml>false</xml>
+                            <fieldNames>false</fieldNames>
+                            <responseHeaders>false</responseHeaders>
+                            <requestHeaders>false</requestHeaders>
+                            <responseDataOnError>false</responseDataOnError>
+                            <saveAssertionResultsFailureMessage>false</saveAssertionResultsFailureMessage>
+                            <assertionsResultsToSave>0</assertionsResultsToSave>
+                        </value>
+                        <name>saveConfig</name>
+                    </objProp>
+                    <stringProp name="filename"></stringProp>
+                    <boolProp name="ResultCollector.error_logging">false</boolProp>
+                </ResultCollector>
+                <hashTree/>
+            </hashTree>
+        </hashTree>
+    </hashTree>
+</jmeterTestPlan>


### PR DESCRIPTION
When scanning for jmeter files, If "includes" only has one row with separated values by 'comma', then a new List is build with those values as rows,	and the jmx extension will be added to those values if it's needed.

This is usefull when passing parameters to maven:
<testFilesIncluded>
		<jMeterTestFile>${jmeter-suites}</jMeterTestFile>
</testFilesIncluded>