### PR TITLE
Add debug output for JVM args

### DIFF
--- a/src/main/java/com/lazerycode/jmeter/configuration/JMeterCommandLineArguments.java
+++ b/src/main/java/com/lazerycode/jmeter/configuration/JMeterCommandLineArguments.java
@@ -2,7 +2,7 @@ package com.lazerycode.jmeter.configuration;
 
 /**
  * An Enum holding all of the command line arguments accepted by JMeter
- * The values are defined in a specific order to ensure the order attributes are applied to the ocmmand line.
+ * The values are defined in a specific order to ensure the order attributes are applied to the command line.
  *
  * @author Mark Collin
  */

--- a/src/main/java/com/lazerycode/jmeter/testrunner/JMeterProcessBuilder.java
+++ b/src/main/java/com/lazerycode/jmeter/testrunner/JMeterProcessBuilder.java
@@ -42,16 +42,22 @@ public class JMeterProcessBuilder {
 		}
 	}
 
-	private String[] constructArgumentsList() {
-		String mainClass = "ApacheJMeter.jar";
-
-		List<String> argumentsList = new ArrayList<String>();
-		argumentsList.add(javaRuntime);
+	public ArrayList<String> getJVMArgumentsList() {
+		ArrayList<String> argumentsList = new ArrayList<String>();
 		argumentsList.add(MessageFormat.format("-Xms{0}M", String.valueOf(this.initialHeapSizeInMegaBytes)));
 		argumentsList.add(MessageFormat.format("-Xmx{0}M", String.valueOf(this.maximumHeapSizeInMegaBytes)));
 		for (String argument : userSuppliedArguments) {
 			argumentsList.add(argument);
 		}
+		return argumentsList;
+	}
+
+	private String[] constructArgumentsList() {
+		String mainClass = "ApacheJMeter.jar";
+
+		List<String> argumentsList = new ArrayList<String>();
+		argumentsList.add(javaRuntime);
+		argumentsList.addAll(getJVMArgumentsList());
 
 		argumentsList.add("-jar");
 		argumentsList.add(mainClass);

--- a/src/main/java/com/lazerycode/jmeter/testrunner/TestManager.java
+++ b/src/main/java/com/lazerycode/jmeter/testrunner/TestManager.java
@@ -87,13 +87,14 @@ public class TestManager extends JMeterMojo {
 		List<String> argumentsArray = testArgs.buildArgumentsArray();
 		argumentsArray.addAll(buildRemoteArgs(remoteServerConfiguration));
 		getLog().debug("JMeter is called with the following command line arguments: " + UtilityFunctions.humanReadableCommandLineOutput(argumentsArray));
+		JMeterProcessBuilder jMeterProcessBuilder = new JMeterProcessBuilder(jMeterProcessJVMSettings);
+		getLog().debug("JMeter is called with the following JVM arguments: " + UtilityFunctions.humanReadableCommandLineOutput(jMeterProcessBuilder.getJVMArgumentsList()));
+		jMeterProcessBuilder.setWorkingDirectory(binDir);
+		jMeterProcessBuilder.addArguments(argumentsArray);
 		getLog().info("Executing test: " + test.getName());
 		//Start the test.
-		JMeterProcessBuilder JMeterProcessBuilder = new JMeterProcessBuilder(jMeterProcessJVMSettings);
-		JMeterProcessBuilder.setWorkingDirectory(binDir);
-		JMeterProcessBuilder.addArguments(argumentsArray);
 		try {
-			final Process process = JMeterProcessBuilder.startProcess();
+			final Process process = jMeterProcessBuilder.startProcess();
 			BufferedReader br = new BufferedReader(new InputStreamReader(process.getInputStream()));
 			String line;
 			while ((line = br.readLine()) != null) {


### PR DESCRIPTION
Closes #129

If no non-default settings are specified in pom.xml, default debug output includes:
`[debug] JMeter is called with the following JVM arguments: -Xms512M -Xmx512M`

If some settings are set, they are included in debug output, e.g.:
`[debug] JMeter is called with the following JVM arguments: -Xms1024M -Xmx1024M -DsocksProxyHost=localhost -DsocksProxyPort=8080`