### PR TITLE
Add support for more than one custom properties file

### DIFF
--- a/src/main/java/com/lazerycode/jmeter/JMeterAbstractMojo.java
+++ b/src/main/java/com/lazerycode/jmeter/JMeterAbstractMojo.java
@@ -135,7 +135,7 @@ public abstract class JMeterAbstractMojo extends AbstractMojo {
 	 * Absolute path to JMeter custom (test dependent) properties file.
 	 */
 	@Parameter
-	protected File customPropertiesFile;
+	protected List<File> customPropertiesFiles;
 
 	/**
 	 * Replace the default JMeter properties with any custom properties files supplied.
@@ -462,7 +462,9 @@ public abstract class JMeterAbstractMojo extends AbstractMojo {
 			}
 		}
 		testArgs.setProxyConfig(proxyConfig);
-		testArgs.setACustomPropertiesFile(customPropertiesFile);
+		for (File customPropertiesFile : customPropertiesFiles) {
+			testArgs.setACustomPropertiesFile(customPropertiesFile);
+		}
 		testArgs.setLogRootOverride(overrideRootLogLevel);
 		testArgs.setLogsDirectory(logsDir.getAbsolutePath());
 	}

--- a/src/main/java/com/lazerycode/jmeter/configuration/JMeterArgumentsArray.java
+++ b/src/main/java/com/lazerycode/jmeter/configuration/JMeterArgumentsArray.java
@@ -32,7 +32,7 @@ public class JMeterArgumentsArray {
 	private boolean appendTimestamp = false;
 	private String resultFileExtension = ".jtl";
 	private String remoteStartServerList;
-	private String customPropertiesFile;
+	private List<String> customPropertiesFiles = new ArrayList<>();
 	private String testFile;
 	private String resultsLogFileName;
 	private String jmeterLogFileName;
@@ -106,7 +106,7 @@ public class JMeterArgumentsArray {
 
 	public void setACustomPropertiesFile(File customProperties) {
 		if (isNotSet(customProperties)) return;
-		customPropertiesFile = customProperties.getAbsolutePath();
+		customPropertiesFiles.add(customProperties.getAbsolutePath());
 		argumentList.add(PROPFILE2_OPT);
 	}
 
@@ -207,8 +207,10 @@ public class JMeterArgumentsArray {
 					argumentsArray.add(overrideRootLogLevel.toString());
 					break;
 				case PROPFILE2_OPT:
-					argumentsArray.add(PROPFILE2_OPT.getCommandLineArgument());
-					argumentsArray.add(customPropertiesFile);
+					for (String customPropertiesFile : customPropertiesFiles) {
+						argumentsArray.add(PROPFILE2_OPT.getCommandLineArgument());
+						argumentsArray.add(customPropertiesFile);
+					}
 					break;
 				case REMOTE_OPT:
 					argumentsArray.add(REMOTE_OPT.getCommandLineArgument());

--- a/src/test/java/com/lazerycode/jmeter/configuration/JMeterArgumentsArrayTest.java
+++ b/src/test/java/com/lazerycode/jmeter/configuration/JMeterArgumentsArrayTest.java
@@ -86,6 +86,20 @@ public class JMeterArgumentsArrayTest {
 	}
 
 	@Test
+	public void validateJMeterCustomPropertiesFiles() throws Exception {
+		JMeterArgumentsArray testArgs = new JMeterArgumentsArray(disableGUI, "target/jmeter/");
+		testArgs.setTestFile(new File(this.testFile.toURI()));
+
+		File testPropFile = new File("test.properties");
+		File secondTestPropFile = new File("secondTest.properties");
+		testArgs.setACustomPropertiesFile(testPropFile);
+		testArgs.setACustomPropertiesFile(secondTestPropFile);
+
+		assertThat(UtilityFunctions.humanReadableCommandLineOutput(testArgs.buildArgumentsArray()),
+				is(equalTo("-n -t " + testFilePath + " -l " + testArgs.getResultsLogFileName() + " -d target/jmeter/ -q " + testPropFile.getAbsolutePath() + " -q " + secondTestPropFile.getAbsolutePath())));
+	}
+
+	@Test
 	public void validateSetRootLogLevel() throws Exception {
 		JMeterArgumentsArray testArgs = new JMeterArgumentsArray(disableGUI, "target/jmeter/");
 		testArgs.setTestFile(new File(this.testFile.toURI()));


### PR DESCRIPTION
JMeter allows more than one additional property file [(-q, --addprop)](http://jmeter.apache.org/usermanual/get-started.html#options). The way jmeter-maven-plugin is designed [at the moment](https://github.com/jmeter-maven-plugin/jmeter-maven-plugin/search?utf8=%E2%9C%93&q=customPropertiesFile), allows support for only one additional properties file. This PR will sync behaviour of jmeter-maven-plugin with JMeter itself.

Please note:
1) This is a breaking change, as now plugin will be looking for this:

                            <customPropertiesFiles>
                                <customerPropertiesFile>someFile</customerPropertiesFile>
                                <customerPropertiesFile>someOtherFile</customerPropertiesFile>
                            </customPropertiesFiles>

Rather than that:

                            <customPropertiesFile>someFile</customPropertiesFile>
I considered keeping the old functionality alongside the new one, but this would make the code a bit messy. Also, as the next version is 2.0.0, according to semantic versioning there is nothing wrong with introducing breaking changes.

2) I was unable to use JAR generated with `mvn plugin:descriptor install` from master (prior to my changes). By use I mean `mvn test` in the project where I use jmeter-maven-plugin:

    [ERROR] Failed to execute goal com.lazerycode.jmeter:jmeter-maven-plugin:2.0.0-SNAPSHOT:jmeter
    (jmeter-tests) on project jmeter-maven-project: Unable to parse configuration of mojo
    com.lazerycode.jmeter:jmeter-maven-plugin:2.0.0-SNAPSHOT:jmeter for parameter pluginArtifacts:
    Cannot find 'pluginArtifacts' in class com.lazerycode.jmeter.JMeterMojo -> [Help 1]

To test my changes, I did [git revert 9781595e8efe978ad2c30a824e6bc84ccdcae592](https://github.com/automatictester/jmeter-maven-plugin/commit/9781595e8efe978ad2c30a824e6bc84ccdcae592).