### PR TITLE
Fix scanning result files

### DIFF
--- a/src/it/basic-run/pom.xml
+++ b/src/it/basic-run/pom.xml
@@ -35,6 +35,8 @@
                 <version>@project.version@</version>
                 <configuration>
                     <suppressJMeterOutput>false</suppressJMeterOutput>
+                    <scanResultsForFailedRequests>true</scanResultsForFailedRequests>
+                    <scanResultsForSuccessfulRequests>true</scanResultsForSuccessfulRequests>
                     <testFilesIncluded>
                         <testFilesIncluded>test.jmx</testFilesIncluded>
                     </testFilesIncluded>

--- a/src/main/java/com/lazerycode/jmeter/mojo/AbstractJMeterMojo.java
+++ b/src/main/java/com/lazerycode/jmeter/mojo/AbstractJMeterMojo.java
@@ -183,7 +183,6 @@ public abstract class AbstractJMeterMojo extends AbstractMojo {
 	protected static JMeterArgumentsArray testArgs;
 	protected boolean resultsOutputIsCSVFormat = false;
 	protected static File workingDirectory;
-	protected List<String> resultFilesLocations;
 	protected static Map<ConfigurationFiles, PropertiesMapping> propertiesMap = new HashMap<>();
 
 	//==================================================================================================================

--- a/src/main/java/com/lazerycode/jmeter/mojo/RunJMeterMojo.java
+++ b/src/main/java/com/lazerycode/jmeter/mojo/RunJMeterMojo.java
@@ -53,7 +53,7 @@ public class RunJMeterMojo extends AbstractJMeterMojo {
 		if (proxyConfig != null) {
 			getLog().info(this.proxyConfig.toString());
 		}
-		resultFilesLocations = jMeterTestManager.executeTests();
+		jMeterTestManager.executeTests();
 	}
 
 	static void CopyFilesInTestDirectory(File sourceDirectory, File destinationDirectory) throws IOException {

--- a/src/main/java/com/lazerycode/jmeter/testrunner/ResultScanner.java
+++ b/src/main/java/com/lazerycode/jmeter/testrunner/ResultScanner.java
@@ -4,7 +4,6 @@ import com.lazerycode.jmeter.exceptions.ResultsFileNotFoundException;
 
 import java.io.File;
 import java.io.FileNotFoundException;
-import java.io.IOException;
 import java.util.Scanner;
 
 /**
@@ -34,10 +33,10 @@ public class ResultScanner {
 	 */
 	public void parseResultFile(File file) throws ResultsFileNotFoundException {
 		if (countFailures) {
-			failureCount = failureCount + scanFileforPattern(file, REQUEST_FAILURE);
+			failureCount = failureCount + scanFileForPattern(file, REQUEST_FAILURE);
 		}
 		if (countSuccesses) {
-			successCount = successCount + scanFileforPattern(file, REQUEST_SUCCESS);
+			successCount = successCount + scanFileForPattern(file, REQUEST_SUCCESS);
 		}
 	}
 
@@ -49,7 +48,7 @@ public class ResultScanner {
 	 * @return The number of times the pattern has been found
 	 * @throws ResultsFileNotFoundException
 	 */
-	private int scanFileforPattern(File file, String pattern) throws ResultsFileNotFoundException {
+	private int scanFileForPattern(File file, String pattern) throws ResultsFileNotFoundException {
 		int patternCount = 0;
 		try (Scanner resultFileScanner = new Scanner(file)) {
 			while (resultFileScanner.findWithinHorizon(pattern, 0) != null) {


### PR DESCRIPTION
Make the `results` goal always scan jtl files in the "results" directory
The field `resultFilesLocations` is never set except in `RunJMeterMojo`. However
this can't be used by `CheckResultsMojo` since it's a completely different
execution. Make the results goal always scan all jtl files.

One potential drawback is that it will scan result files that were not generated
by the same maven execution. That said it can also be considered an advantage if
the goal needs to be run later. If not then the recommendation is to run clean
before running the tests.

Fixes #190
