### PR TITLE
fix for avoiding conflicts between jmeter libraries and given <jmeter…

### DIFF
--- a/src/main/java/com/lazerycode/jmeter/mojo/ConfigureJMeterMojo.java
+++ b/src/main/java/com/lazerycode/jmeter/mojo/ConfigureJMeterMojo.java
@@ -368,7 +368,7 @@ public class ConfigureJMeterMojo extends AbstractJMeterMojo {
 					getLog().debug("-------------------------------------------------------");
 				}
 				Artifact returnedArtifact = getArtifactResult(dependency.getArtifact());
-				if (!returnedArtifact.getArtifactId().startsWith("ApacheJMeter_")) {
+				if (!returnedArtifact.getArtifactId().startsWith("ApacheJMeter_") && !isArtefactContainedInExtensions(returnedArtifact)) {
 					copyArtifact(returnedArtifact, libDirectory);
 				}
 			}
@@ -376,6 +376,24 @@ public class ConfigureJMeterMojo extends AbstractJMeterMojo {
 			throw new DependencyResolutionException(e.getMessage(), e);
 		}
 	}
+
+	/**
+	 * Is the given artifact contained in the given extensions
+	 *
+	 * @param artifact the artifact to be checked
+	 * @return is the given artifact contained in the extensions
+	 * @throws DependencyResolutionException
+	 */
+	private boolean isArtefactContainedInExtensions(Artifact artifact) throws DependencyResolutionException {
+		for (String extensionArtifactStr : jmeterExtensions)	{
+			Artifact extensionArtifact = getArtifactResult(new DefaultArtifact(extensionArtifactStr));
+			if (artifact.getGroupId().equals(extensionArtifact.getGroupId()) && artifact.getArtifactId().equals(extensionArtifact.getArtifactId())) {
+				return true;
+			}
+		}
+		return false;
+	}
+
 
 	/**
 	 * Copy an Artifact to a directory


### PR DESCRIPTION
problem solved here:
My load test needs its own bouncy castle lib, which I provide within <jmeterExtensions>. Since jmeter brings a different bouncy castle version I end up with 2 bouncy castle libraries on the classpath.
Please consider pulling this change in. 
