### PR TITLE
Support response messages containing booleans when scanning csv results

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -40,6 +40,7 @@
         <mockito-core.version>2.22.0</mockito-core.version>
         <byte-buddy.version>1.9.0</byte-buddy.version>
         <slf4j-api.version>1.7.25</slf4j-api.version>
+        <jackson.version>2.9.3</jackson.version>
 
         <!--Plugin versions-->
         <maven-compiler-plugin.version>3.8.0</maven-compiler-plugin.version>
@@ -258,6 +259,11 @@
             <groupId>org.eclipse.aether</groupId>
             <artifactId>aether-api</artifactId>
             <version>${aether.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.dataformat</groupId>
+            <artifactId>jackson-dataformat-csv</artifactId>
+            <version>${jackson.version}</version>
         </dependency>
         <!-- optional helpers, might be superfluous depending on your use case -->
         <dependency>

--- a/src/main/java/com/lazerycode/jmeter/testrunner/ResultScanner.java
+++ b/src/main/java/com/lazerycode/jmeter/testrunner/ResultScanner.java
@@ -1,13 +1,21 @@
 package com.lazerycode.jmeter.testrunner;
 
+import java.io.BufferedReader;
 import java.io.File;
+import java.io.FileInputStream;
 import java.io.FileNotFoundException;
+import java.io.InputStreamReader;
+import java.util.Map;
 import java.util.Scanner;
+
+import com.fasterxml.jackson.databind.MappingIterator;
+import com.fasterxml.jackson.dataformat.csv.CsvMapper;
+import com.fasterxml.jackson.dataformat.csv.CsvSchema;
+import com.lazerycode.jmeter.exceptions.IOException;
+import com.lazerycode.jmeter.exceptions.ResultsFileNotFoundException;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import com.lazerycode.jmeter.exceptions.ResultsFileNotFoundException;
 
 /**
  * Handles checking a JMeter results file in XML format for errors and failures.
@@ -26,7 +34,8 @@ public class ResultScanner implements IResultScanner {
 	private final boolean countSuccesses;
 	private int failureCount = 0;
 	private int successCount = 0;
-    private boolean csv;
+	private boolean csv;
+	private static final CsvMapper CSV_MAPPER = new CsvMapper();
 
 	public ResultScanner(boolean countSuccesses, boolean countFailures, boolean isCsv) {
         this.countFailures = countFailures;
@@ -43,8 +52,10 @@ public class ResultScanner implements IResultScanner {
 	 *
 	 * @param file File to parse
 	 * @throws ResultsFileNotFoundException
+	 * @throws IOException
 	 */
-	public void parseResultFile(File file) throws ResultsFileNotFoundException {
+	public void parseResultFile(File file)
+			throws ResultsFileNotFoundException, IOException {
 	    String failurePattern = this.csv ? CSV_REQUEST_FAILURE : XML_REQUEST_FAILURE;
 	    String successPattern = this.csv ? CSV_REQUEST_SUCCESS : XML_REQUEST_SUCCESS;
 	    LOGGER.info("Parsing results file '{}' in format '{}', using failurePattern:'{}', successPattern:'{}'",
@@ -65,23 +76,80 @@ public class ResultScanner implements IResultScanner {
 	 * @param pattern The pattern to look for
 	 * @return The number of times the pattern has been found
 	 * @throws ResultsFileNotFoundException
+	 * @throws IOException
 	 */
-	private int scanFileForPattern(File file, String pattern) 
-	        throws ResultsFileNotFoundException { // NOSONAR
+	private int scanFileForPattern(File file, String pattern)
+			throws ResultsFileNotFoundException, IOException { // NOSONAR
 		int patternCount = 0;
 		LOGGER.debug("Scanning file '{}' using pattern '{}'", file.getAbsolutePath(), pattern);
-		try (Scanner resultFileScanner = new Scanner(file)) {
-			while (resultFileScanner.findWithinHorizon(pattern, 0) != null) {
-				patternCount++;
-			}
+		try {
+			if (csv)
+				patternCount = scanCsvForPattern(file, pattern);
+			else
+				patternCount = scanXmlForPattern(file, pattern);
 		} catch (FileNotFoundException ex) {
 			throw new ResultsFileNotFoundException("File not found for file:"
 			        +file.getAbsolutePath()
 			        +", pattern:"
 			        +pattern, ex);
 		}
-        LOGGER.debug("Scanned file '{}' using pattern '{}', result:'{}'", file.getAbsolutePath(), pattern, patternCount);
+		LOGGER.debug("Scanned file '{}' using pattern '{}', result:'{}'", file.getAbsolutePath(), pattern, patternCount);
 
+		return patternCount;
+	}
+
+	/**
+	 * Scans a csv file for the given pattern and returns the number of times
+	 * the pattern appears in the success column. This function assumes that the
+	 * csv will always include the header row.
+	 * @param file    The file to parse
+	 * @param pattern The pattern to look for
+	 * @return The number of times the pattern appears in the success column
+	 * @throws IOException When an error occurs while reading the file
+	 */
+	private int scanCsvForPattern(File file, String pattern) throws IOException {
+		CsvSchema schema = CsvSchema.emptySchema().withHeader();
+		int bufferSize = 1024 * 1024;
+		int patternCount = 0;
+
+		try (FileInputStream fis = new FileInputStream(file);
+				InputStreamReader isr = new InputStreamReader(fis);
+				BufferedReader reader = new BufferedReader(isr, bufferSize)) {
+
+			MappingIterator<Map<String, String>> it = CSV_MAPPER.readerFor(Map.class)
+					.with(schema)
+					.readValues(reader);
+					
+			while (it.hasNext()) {
+				Map<String, String> row = it.next();
+				String success = row.get("success");
+				if (success != null && success.matches(pattern))
+					patternCount++;
+			}
+		} catch (java.io.IOException e) {
+			String message = "An unexpected error occured while reading file "
+					+ file.getAbsolutePath();
+			throw new IOException(message, e);
+		}
+		return patternCount;
+	}
+
+	/**
+	 * Scans an xml file for the given pattern and returns the number of times the
+	 * pattern appears in the xml.
+	 * @param file    The file to parse
+	 * @param pattern The pattern to look for
+	 * @return The number of times the pattern appears in the xml file
+	 * @throws FileNotFoundException When the file is not found
+	 */
+	private int scanXmlForPattern(File file, String pattern) 
+			throws FileNotFoundException {
+		int patternCount = 0;
+		try (Scanner resultFileScanner = new Scanner(file)) {
+			while (resultFileScanner.findWithinHorizon(pattern, 0) != null) {
+				patternCount++;
+			}
+		}
 		return patternCount;
 	}
 

--- a/src/test/java/com/lazerycode/jmeter/ResultScannerTest.java
+++ b/src/test/java/com/lazerycode/jmeter/ResultScannerTest.java
@@ -16,12 +16,14 @@ public class ResultScannerTest {
 	private static final boolean DO_NOT_COUNT_FAILURES = false;
 	private static final boolean COUNT_SUCCESSES = true;
 	private static final boolean DO_NOT_COUNT_SUCCESSES = false;
-	private final URL failingResultsFileURL = this.getClass().getResource("/jtl2-1-fail.jtl");
-	private final URL passingResultsFileURL = this.getClass().getResource("/jtl2-1-pass.jtl");
+	private final URL jtlFailingResultsFileURL = this.getClass().getResource("/jtl2-1-fail.jtl");
+	private final URL jtlPassingResultsFileURL = this.getClass().getResource("/jtl2-1-pass.jtl");
+	private final URL csvFailingResultsFileURL = this.getClass().getResource("/csv2-1-fail.csv");
+	private final URL csvPassingResultsFileURL = this.getClass().getResource("/csv2-1-pass.csv");
 
 	@Test
 	public void jtlFileWithFailuresCountSuccessAndFailures() throws Exception {
-		File resultsFile = new File(failingResultsFileURL.toURI());
+		File resultsFile = new File(jtlFailingResultsFileURL.toURI());
 		ResultScanner fileScanner = new ResultScanner(COUNT_SUCCESSES, COUNT_FAILURES);
 		fileScanner.parseResultFile(resultsFile);
 
@@ -33,7 +35,7 @@ public class ResultScannerTest {
 
 	@Test
 	public void jtlFileWithFailuresCountSuccessesOnly() throws Exception {
-		File resultsFile = new File(failingResultsFileURL.toURI());
+		File resultsFile = new File(jtlFailingResultsFileURL.toURI());
 		ResultScanner fileScanner = new ResultScanner(COUNT_SUCCESSES, DO_NOT_COUNT_FAILURES);
 		fileScanner.parseResultFile(resultsFile);
 
@@ -45,7 +47,7 @@ public class ResultScannerTest {
 
 	@Test
 	public void jtlFileWithFailuresCountFailuresOnly() throws Exception {
-		File resultsFile = new File(failingResultsFileURL.toURI());
+		File resultsFile = new File(jtlFailingResultsFileURL.toURI());
 		ResultScanner fileScanner = new ResultScanner(DO_NOT_COUNT_SUCCESSES, COUNT_FAILURES);
 		fileScanner.parseResultFile(resultsFile);
 
@@ -57,7 +59,7 @@ public class ResultScannerTest {
 
 	@Test
 	public void jtlFileWithNoFailuresCountSuccessAndFailures() throws Exception {
-		File resultsFile = new File(passingResultsFileURL.toURI());
+		File resultsFile = new File(jtlPassingResultsFileURL.toURI());
 		ResultScanner fileScanner = new ResultScanner(COUNT_SUCCESSES, COUNT_FAILURES);
 		fileScanner.parseResultFile(resultsFile);
 
@@ -69,7 +71,7 @@ public class ResultScannerTest {
 
 	@Test
 	public void jtlFileWithNoFailuresCountSuccessesOnly() throws Exception {
-		File resultsFile = new File(passingResultsFileURL.toURI());
+		File resultsFile = new File(jtlPassingResultsFileURL.toURI());
 		ResultScanner fileScanner = new ResultScanner(COUNT_SUCCESSES, DO_NOT_COUNT_FAILURES);
 		fileScanner.parseResultFile(resultsFile);
 
@@ -81,7 +83,7 @@ public class ResultScannerTest {
 
 	@Test
 	public void jtlFileWithNoFailuresCountFailuresOnly() throws Exception {
-		File resultsFile = new File(passingResultsFileURL.toURI());
+		File resultsFile = new File(jtlPassingResultsFileURL.toURI());
 		ResultScanner fileScanner = new ResultScanner(DO_NOT_COUNT_SUCCESSES, COUNT_FAILURES);
 		fileScanner.parseResultFile(resultsFile);
 
@@ -89,5 +91,31 @@ public class ResultScannerTest {
 				is(equalTo(0)));
 		assertThat(fileScanner.getSuccessCount(),
 				is(equalTo(0)));
+	}
+
+	@Test
+	public void csvFileWithFailuresCountSuccessAndFailures() throws Exception {
+		File resultsFile = new File(csvFailingResultsFileURL.toURI());
+		ResultScanner fileScanner = new ResultScanner(
+				COUNT_SUCCESSES, COUNT_FAILURES, true);
+		fileScanner.parseResultFile(resultsFile);
+
+		assertThat(fileScanner.getFailureCount(),
+				is(equalTo(2)));
+		assertThat(fileScanner.getSuccessCount(),
+				is(equalTo(0)));
+	}
+
+	@Test
+	public void csvFileWithNoFailuresCountSuccessAndFailures() throws Exception {
+		File resultsFile = new File(csvPassingResultsFileURL.toURI());
+		ResultScanner fileScanner = new ResultScanner(
+				COUNT_SUCCESSES, COUNT_FAILURES, true);
+		fileScanner.parseResultFile(resultsFile);
+
+		assertThat(fileScanner.getFailureCount(),
+				is(equalTo(0)));
+		assertThat(fileScanner.getSuccessCount(),
+				is(equalTo(2)));
 	}
 }

--- a/src/test/resources/csv2-1-fail.csv
+++ b/src/test/resources/csv2-1-fail.csv
@@ -1,0 +1,3 @@
+timeStamp,elapsed,label,responseCode,responseMessage,threadName,dataType,success,failureMessage,bytes,sentBytes,grpThreads,allThreads,URL,Latency,IdleTime,Connect
+1548568307205,1330,test-request,200,"some message with true",my-test-plan 1-1,,false,,0,0,3,3,null,0,0,0
+1548568307206,2550,test-request,200,"<Foo Bar=""true""></Foo>",my-test-plan 1-1,,false,,0,0,3,3,null,0,0,0

--- a/src/test/resources/csv2-1-pass.csv
+++ b/src/test/resources/csv2-1-pass.csv
@@ -1,0 +1,3 @@
+timeStamp,elapsed,label,responseCode,responseMessage,threadName,dataType,success,failureMessage,bytes,sentBytes,grpThreads,allThreads,URL,Latency,IdleTime,Connect
+1548568307205,1330,test-request,200,"some message with false",my-test-plan 1-1,,true,,0,0,3,3,null,0,0,0
+1548568307206,2550,test-request,200,"<Foo Bar=""false""></Foo>",my-test-plan 1-1,,true,,0,0,3,3,null,0,0,0

--- a/src/test/resources/jtl2-1-fail.jtl
+++ b/src/test/resources/jtl2-1-fail.jtl
@@ -3,5 +3,5 @@
     <httpSample t="1187" lt="0" ts="1133521593546" s="true" lb="/my_webapp/root/auth" rc="302" rm="Moved Temporarily" tn="Thread Group 1-1" dt="text"/>
     <httpSample t="16" lt="0" ts="1133521593562" s="false" lb="/my_webapp/root/;jsessionid=xxx" rc="302" rm="Moved Temporarily" tn="Thread Group 1-1" dt="text"/>
     <httpSample t="16" lt="0" ts="1133521593578" s="true" lb="/my_webapp/root/portal" rc="302" rm="Moved Temporarily" tn="Thread Group 1-1" dt="text"/>
-    <httpSample t="15" lt="0" ts="1133521593593" s="false" lb="/my_webapp/root/docbook/css/docbook.css" rc="304" rm="Not Modified" tn="Thread Group 1-1" dt=""/>
+    <httpSample t="15" lt="0" ts="1133521593593" s="false" lb="/my_webapp/root/docbook/css/docbook.css" rc="304" rm="true" tn="Thread Group 1-1" dt=""/>
 </testResults>

--- a/src/test/resources/jtl2-1-pass.jtl
+++ b/src/test/resources/jtl2-1-pass.jtl
@@ -3,5 +3,5 @@
     <httpSample t="1187" lt="0" ts="1133521593546" s="true" lb="/my_webapp/root/auth" rc="302" rm="Moved Temporarily" tn="Thread Group 1-1" dt="text"/>
     <httpSample t="16" lt="0" ts="1133521593562" s="true" lb="/my_webapp/root/;jsessionid=xxx" rc="302" rm="Moved Temporarily" tn="Thread Group 1-1" dt="text"/>
     <httpSample t="16" lt="0" ts="1133521593578" s="true" lb="/my_webapp/root/portal" rc="302" rm="Moved Temporarily" tn="Thread Group 1-1" dt="text"/>
-    <httpSample t="15" lt="0" ts="1133521593593" s="true" lb="/my_webapp/root/docbook/css/docbook.css" rc="304" rm="Not Modified" tn="Thread Group 1-1" dt=""/>
+    <httpSample t="15" lt="0" ts="1133521593593" s="true" lb="/my_webapp/root/docbook/css/docbook.css" rc="304" rm="false" tn="Thread Group 1-1" dt=""/>
 </testResults>


### PR DESCRIPTION
This PR attempts to resolve #305.

@pmouawad I checked out the example you linked, and began by attempting your suggestion, but was hesitant to bring in JMeter as a dependency to read user.properties and return a SampleSaveConfiguration to detect position of the success column.

In this proposal, I'm using Jackson to deserialize the csv rows as a map, then comparing the value of the success field with the given pattern. It does however depend on the header row to be included. Are there any use cases where there would be no header?

I've also slightly modified the existing jtl examples to add coverage for response messages containing "true" or "false" in xml.

Would appreciate any feedback, thanks!