### PR TITLE
New optional property for jmeter:gui mojo

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -15,7 +15,7 @@
 
     <groupId>com.lazerycode.jmeter</groupId>
     <artifactId>jmeter-maven-plugin</artifactId>
-    <version>DEV-SNAPSHOT</version>
+    <version>3.3.0</version>
     <packaging>maven-plugin</packaging>
 
     <name>JMeter Maven Plugin</name>

--- a/src/main/java/com/lazerycode/jmeter/mojo/AbstractJMeterMojo.java
+++ b/src/main/java/com/lazerycode/jmeter/mojo/AbstractJMeterMojo.java
@@ -200,7 +200,7 @@ public abstract class AbstractJMeterMojo extends AbstractMojo {
     protected String testConfigFile;
 
     /**
-     * The filename used to store the results config
+     * The config name used for jmeter run. Configuration id is taken from jmeter:configure execution id
      */
     @Parameter(defaultValue = DEFAULT_CONFIG_EXECUTION_ID)
     protected String selectedConfiguration;

--- a/src/main/java/com/lazerycode/jmeter/mojo/RunJMeterGUIMojo.java
+++ b/src/main/java/com/lazerycode/jmeter/mojo/RunJMeterGUIMojo.java
@@ -33,6 +33,10 @@ public class RunJMeterGUIMojo extends AbstractJMeterMojo {
     @Parameter(defaultValue = "${guiTestFile}")
     private File guiTestFile;
 
+    public static final String CLI_CONFIG_EXECUTION_ID = "default-cli";
+
+    @Parameter(property = "jmeter.gui.config.id", defaultValue = "default-cli")
+    private String guiConfigurationId;
     /**
      * Load the JMeter GUI
      *
@@ -44,7 +48,18 @@ public class RunJMeterGUIMojo extends AbstractJMeterMojo {
         getLog().info(LINE_SEPARATOR);
         getLog().info(" S T A R T I N G    J M E T E R    G U I ");
         getLog().info(LINE_SEPARATOR);
-        testConfig = new TestConfigurationWrapper(new File(testConfigFile), this.mojoExecution.getExecutionId());
+        if (this.mojoExecution.getExecutionId().equals(CLI_CONFIG_EXECUTION_ID)) {//plugin called from cli
+            //it is compatible with current behaviour eg.: mvn jmeter:configure jmeter:gui (config name is default-cli by default)
+            //it makes possible: e.g. mvn compile jmeter:gui -Djmeter.gui.config.id=configuration1
+            testConfig = new TestConfigurationWrapper(new File(testConfigFile), guiConfigurationId);
+        } else {//when jmeter:configure and jmeter:gui called from pom
+            // check if user set property (configuration name) in cli
+            if (!"default-cli".equalsIgnoreCase(guiConfigurationId)) {//use config name from property
+                testConfig = new TestConfigurationWrapper(new File(testConfigFile), guiConfigurationId);
+            } else {//take config from <selectedConfiguration>someconfig</selectedConfiguration>
+                testConfig = new TestConfigurationWrapper(new File(testConfigFile), selectedConfiguration);
+            }
+        }
         startJMeterGUI(initialiseJMeterArgumentsArray());
     }
 


### PR DESCRIPTION
Hi,
This PR introduce new and optional property for jmeter:gui mojo. The name of the property is **jmeter.gui.config.id** and it allows to name configuration for gui (configuration is created by jmeter:configuration goal). The default name for configuration is currently always "default-cli" which is equal to executionId of goal when called from cli. This change is backward compatibile. It allows to run command e.g. mvn package jmeter:gui -Djmeter.gui.config.id=configuration1  where configuration is created in pom by jmeter:configuration and has any name. Without this change when jmeter:gui is called from cli and jmeter:configuration in pom then configuration name in pom has to be "default-cli".